### PR TITLE
fix: use default value if current value is invalid

### DIFF
--- a/src/v4l2_camera.cpp
+++ b/src/v4l2_camera.cpp
@@ -273,6 +273,9 @@ void V4L2Camera::createParameters()
           range.from_value = c.minimum;
           range.to_value = c.maximum;
           descriptor.integer_range.push_back(range);
+          if (current_value < c.minimum || c.maximum < current_value) {
+            current_value = c.defaultValue;
+          }
           auto value = declare_parameter<int64_t>(name, current_value, descriptor);
           camera_->setControlValue(c.id, value);
           break;


### PR DESCRIPTION
Some cameras have parameters with invalid values set on boot, which causes errors at subsequent `setControleValue`. This PR replaces the current value with the default value (i.e., valid value) to avoid the error.