### PR TITLE
Feature/use v4l2 buffer timestamps

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,21 @@ publishes images as `sensor_msgs/Image` messages.
     another period near to it. In that case the parameter change is
     reported to have failed.
 
+* `use_v4l2_buffer_timestamps` - `bool`, default: `true`
+
+    Flag to determine image timestamp behaviour. When `true`, the images
+    will be timestamped according to the V4L2 buffer timestamps. When
+    `false` the image timestamps will be the system time when the image
+    buffer is read.
+
+* `timestamp_offset` - `int64_t`, default: `0`
+
+    Offset to be added to the image timestamp, in nanoseconds. This is
+    useful to correct for delays in the image capture pipeline, when
+    performing synchronization with other sensor data. Note that this 
+    value will usually be negative (correcting for delays rather than 
+    adding delay to the timestamp).
+
 * Camera Control Parameters
 
     Camera controls, such as brightness, contrast, white balance, etc,

--- a/include/v4l2_camera/v4l2_camera_device.hpp
+++ b/include/v4l2_camera/v4l2_camera_device.hpp
@@ -36,7 +36,7 @@ namespace v4l2_camera
 class V4l2CameraDevice
 {
 public:
-  explicit V4l2CameraDevice(std::string device, bool use_v4l2_buffer_timestamps);
+  explicit V4l2CameraDevice(std::string device, bool use_v4l2_buffer_timestamps, rclcpp::Duration timestamp_offset_duration);
 
   bool open();
   bool start();
@@ -98,6 +98,7 @@ private:
   std::string device_;
   int fd_;
   bool use_v4l2_buffer_timestamps_;
+  rclcpp::Duration timestamp_offset_;
 
   v4l2_capability capabilities_;
   v4l2_captureparm capture_parm_;

--- a/include/v4l2_camera/v4l2_camera_device.hpp
+++ b/include/v4l2_camera/v4l2_camera_device.hpp
@@ -84,6 +84,8 @@ public:
 
   int64_t getTimeOffset();
 
+  void setTSCOffset();
+
   sensor_msgs::msg::Image::UniquePtr capture();
 
 private:
@@ -99,6 +101,7 @@ private:
   int fd_;
   bool use_v4l2_buffer_timestamps_;
   rclcpp::Duration timestamp_offset_;
+  uint64_t tsc_offset_;
 
   v4l2_capability capabilities_;
   v4l2_captureparm capture_parm_;

--- a/include/v4l2_camera/v4l2_camera_device.hpp
+++ b/include/v4l2_camera/v4l2_camera_device.hpp
@@ -15,6 +15,7 @@
 #ifndef V4L2_CAMERA__V4L2_CAMERA_DEVICE_HPP_
 #define V4L2_CAMERA__V4L2_CAMERA_DEVICE_HPP_
 
+#include <rclcpp/rclcpp.hpp>
 #include <sensor_msgs/msg/image.hpp>
 
 #include <map>
@@ -35,7 +36,7 @@ namespace v4l2_camera
 class V4l2CameraDevice
 {
 public:
-  explicit V4l2CameraDevice(std::string device);
+  explicit V4l2CameraDevice(std::string device, bool use_v4l2_buffer_timestamps);
 
   bool open();
   bool start();
@@ -81,6 +82,8 @@ public:
 
   std::string getCameraName();
 
+  int64_t getTimeOffset();
+
   sensor_msgs::msg::Image::UniquePtr capture();
 
 private:
@@ -94,6 +97,7 @@ private:
 
   std::string device_;
   int fd_;
+  bool use_v4l2_buffer_timestamps_;
 
   v4l2_capability capabilities_;
   v4l2_captureparm capture_parm_;

--- a/src/v4l2_camera.cpp
+++ b/src/v4l2_camera.cpp
@@ -63,11 +63,16 @@ V4L2Camera::V4L2Camera(rclcpp::NodeOptions const & options)
   device_descriptor.read_only = true;
   auto device = declare_parameter<std::string>("video_device", "/dev/video0", device_descriptor);
 
-  auto use_v4l2_buffer_timestamps_description = rcl_interfaces::msg::ParameterDescriptor{};
-  use_v4l2_buffer_timestamps_description.description = "Use v4l2 buffer timestamps";
-  auto use_v4l2_buffer_timestamps = declare_parameter<bool>("use_v4l2_buffer_timestamps", true, use_v4l2_buffer_timestamps_description);
+  auto use_v4l2_buffer_timestamps_descriptor = rcl_interfaces::msg::ParameterDescriptor{};
+  use_v4l2_buffer_timestamps_descriptor.description = "Use v4l2 buffer timestamps";
+  auto use_v4l2_buffer_timestamps = declare_parameter<bool>("use_v4l2_buffer_timestamps", true, use_v4l2_buffer_timestamps_descriptor);
 
-  camera_ = std::make_shared<V4l2CameraDevice>(device, use_v4l2_buffer_timestamps);
+  auto timestamp_offset_descriptor = rcl_interfaces::msg::ParameterDescriptor{};
+  timestamp_offset_descriptor.description = "Timestamp offset in nanoseconds";
+  auto timestamp_offset = declare_parameter<int64_t>("timestamp_offset", 0, timestamp_offset_descriptor);
+  rclcpp::Duration timestamp_offset_duration = rclcpp::Duration::from_nanoseconds(timestamp_offset);
+
+  camera_ = std::make_shared<V4l2CameraDevice>(device, use_v4l2_buffer_timestamps, timestamp_offset_duration);
 
   if (!camera_->open()) {
     return;

--- a/src/v4l2_camera.cpp
+++ b/src/v4l2_camera.cpp
@@ -58,7 +58,12 @@ V4L2Camera::V4L2Camera(rclcpp::NodeOptions const & options)
   device_descriptor.description = "Path to video device";
   device_descriptor.read_only = true;
   auto device = declare_parameter<std::string>("video_device", "/dev/video0", device_descriptor);
-  camera_ = std::make_shared<V4l2CameraDevice>(device);
+
+  auto use_v4l2_buffer_timestamps_description = rcl_interfaces::msg::ParameterDescriptor{};
+  use_v4l2_buffer_timestamps_description.description = "Use v4l2 buffer timestamps";
+  auto use_v4l2_buffer_timestamps = declare_parameter<bool>("use_v4l2_buffer_timestamps", true, use_v4l2_buffer_timestamps_description);
+
+  camera_ = std::make_shared<V4l2CameraDevice>(device, use_v4l2_buffer_timestamps);
 
   if (!camera_->open()) {
     return;
@@ -90,7 +95,7 @@ V4L2Camera::V4L2Camera(rclcpp::NodeOptions const & options)
           continue;
         }
 
-        auto stamp = now();
+        auto stamp = img->header.stamp;
         if (img->encoding != output_encoding_) {
 #ifdef ENABLE_CUDA
           img = convertOnGpu(*img);

--- a/src/v4l2_camera_device.cpp
+++ b/src/v4l2_camera_device.cpp
@@ -215,8 +215,11 @@ std::string V4l2CameraDevice::getCameraName()
 
 int64_t V4l2CameraDevice::getTimeOffset()
 {
-  rclcpp::Time system_time = rclcpp::Clock{RCL_SYSTEM_TIME}.now();
-  rclcpp::Time steady_time = rclcpp::Clock{RCL_STEADY_TIME}.now();
+  timespec system_sample, monotonic_sample;
+  clock_gettime(CLOCK_REALTIME, &system_sample);
+  clock_gettime(CLOCK_MONOTONIC, &monotonic_sample);
+  rclcpp::Time system_time(system_sample.tv_sec, system_sample.tv_nsec);
+  rclcpp::Time steady_time(monotonic_sample.tv_sec, monotonic_sample.tv_nsec);
   return (system_time.nanoseconds() - steady_time.nanoseconds());
 }
 


### PR DESCRIPTION
- Adds timestamp offset parameter
- Tested working V4L2 buffer timestamps

To Do:
- Test with C2 camera
~~- Investigate why a 21ms added delay is introduced when camera is left running for a long period (C1, ROSCube)~~