### PR TITLE
fix(launch): fix default value error which should be string instead of boolean

### DIFF
--- a/launch/v4l2_camera.launch.py
+++ b/launch/v4l2_camera.launch.py
@@ -128,11 +128,11 @@ def generate_launch_description():
                    'otherwise be RELIABLE')
     add_launch_arg('publish_rate', "-1.0",
                    description='publish frame number per second. value <= 0 means no limitation on publish rate')
-    add_launch_arg('use_v4l2_buffer_timestamps', True,
+    add_launch_arg('use_v4l2_buffer_timestamps', 'true',
                    description='flag to use v4l2 buffer timestamps. '
                    'If true, the image timestamps will be applied from the v4l2 buffer, '
                    'otherwise, will be the system time when the buffer is read')
-    add_launch_arg('use_image_transport', True,
+    add_launch_arg('use_image_transport', 'true',
                    description='flag to launch image_transport node')
 
     return LaunchDescription(


### PR DESCRIPTION
# Description

Sorry for introducing new bugs that are not well-fixed in the https://github.com/tier4/ros2_v4l2_camera/pull/22.

This PR makes the default variable string instead of boolean. The grammar/logic has been tested with local launch files.