### PR TITLE
perf: use unique pointer to publish

### DIFF
--- a/src/v4l2_camera.cpp
+++ b/src/v4l2_camera.cpp
@@ -148,8 +148,8 @@ V4L2Camera::V4L2Camera(rclcpp::NodeOptions const & options)
         if (use_image_transport_) {
           camera_transport_pub_.publish(*img, *ci);
         } else {
-          image_pub_->publish(*img);
-          info_pub_->publish(*ci);
+          image_pub_->publish(std::move(img));
+          info_pub_->publish(std::move(ci));
         }
       }
     }


### PR DESCRIPTION
This PR aims to improve node performance by using a unique pointer with `std::move` to avoid additional memory copy