### PR TITLE
Feature/for l4t36

### DIFF
--- a/include/v4l2_camera/v4l2_camera_device.hpp
+++ b/include/v4l2_camera/v4l2_camera_device.hpp
@@ -120,6 +120,8 @@ private:
 
   void getCaptureParameters();
 
+  bool getL4TMajorVersion(std::string &version);
+
   // Requests and stores all formats available for this camera
   void listImageFormats();
 

--- a/src/v4l2_camera_device.cpp
+++ b/src/v4l2_camera_device.cpp
@@ -230,7 +230,7 @@ int64_t V4l2CameraDevice::getTimeOffset()
 void V4l2CameraDevice::setTSCOffset()
 {
   std::string l4t_major_version;
-  if (!V4l2CameraDevice::getL4TMajorVersion(l4t_major_version)){
+  if (V4l2CameraDevice::getL4TMajorVersion(l4t_major_version)){
     if (std::stoi(l4t_major_version) >= 36) {
       // L4T version >= 36      
       #ifdef __ARM_FEATURE_MRS


### PR DESCRIPTION
- Add l4t-36 support by referring to the following forum:
  - https://forums.developer.nvidia.com/t/how-to-get-the-clock-source-offset-ns-on-jetpack-6/300994
- Modified to branch processing depending on CPU architecture and L4T version.