### PR TITLE
feat: add diagnostics

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,9 +6,9 @@ if(NOT CMAKE_C_STANDARD)
   set(CMAKE_C_STANDARD 99)
 endif()
 
-# Default to C++14
+# Default to C++17
 if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 14)
+  set(CMAKE_CXX_STANDARD 17)
 endif()
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
@@ -51,7 +51,8 @@ ament_target_dependencies(v4l2_camera
   "rclcpp"
   "rclcpp_components"
   "image_transport"
-  "camera_info_manager")
+  "camera_info_manager"
+  "diagnostic_updater")
 
 target_compile_options(v4l2_camera PRIVATE -Werror)
 

--- a/include/v4l2_camera/rate_bound_status.hpp
+++ b/include/v4l2_camera/rate_bound_status.hpp
@@ -115,7 +115,7 @@ private:
                   const RateBoundStatusParam& warn_params,
                   const size_t num_frame_transition = 1,
                   const bool immediate_error_report = true,
-                  std::string name = "rate bound check")
+                  const std::string& name = "rate bound check")
       : DiagnosticTask(name), ok_params_(ok_params), warn_params_(warn_params),
         num_frame_transition_(num_frame_transition),
         immediate_error_report_(immediate_error_report), zero_seen_(false),

--- a/include/v4l2_camera/rate_bound_status.hpp
+++ b/include/v4l2_camera/rate_bound_status.hpp
@@ -58,10 +58,10 @@ private:
   struct StateBase
   {
     StateBase(const unsigned char lv, const std::string m)
-        : level(lv), num_observation(1), msg(m) {}
+        : level(lv), num_observations(1), msg(m) {}
 
     unsigned char level;
-    size_t num_observation;
+    size_t num_observations;
     std::string msg;
   };
 
@@ -181,7 +181,7 @@ private:
     // Otherwise, update candidate
     if (candidate_state_.index() == frame_result.index()) {  // if result has the same status as candidate
       std::visit([](auto& s){
-        s.num_observation += 1;
+        s.num_observations += 1;
       }, candidate_state_);
     } else {
       candidate_state_ = frame_result;
@@ -191,10 +191,10 @@ private:
     // - immediate error report is required and the observed state is error
     // - Or the same state is observed multiple times
     if ((immediate_error_report_ && std::holds_alternative<Error>(candidate_state_)) ||
-        (get_num_observation(candidate_state_) >= num_frame_transition_)) {
+        (get_num_observations(candidate_state_) >= num_frame_transition_)) {
       current_state_ = candidate_state_;
       std::visit([](auto& s) {
-        s.num_observation = 1;
+        s.num_observations = 1;
       }, candidate_state_);
     }
 
@@ -225,7 +225,7 @@ private:
     stat.add("Maximum WARN rate threshold", ss.str());
 
     ss.str("");  // reset contents
-    ss << get_num_observation(candidate_state_);
+    ss << get_num_observations(candidate_state_);
     stat.add("Observed frames", ss.str());
 
     ss.str("");  // reset contents
@@ -250,8 +250,8 @@ protected:
     return std::visit([](const auto& s){return s.level;}, state);
   }
 
-  static size_t get_num_observation(const StateHolder& state) {
-    return std::visit([](const auto& s){return s.num_observation;}, state);
+  static size_t get_num_observations(const StateHolder& state) {
+    return std::visit([](const auto& s){return s.num_observations;}, state);
   }
 
   static std::string get_msg(const StateHolder& state) {

--- a/include/v4l2_camera/rate_bound_status.hpp
+++ b/include/v4l2_camera/rate_bound_status.hpp
@@ -25,7 +25,7 @@
 #include <mutex>
 #include <stdexcept>
 
-namespace rate_bound_status
+namespace custom_diagnostic_tasks
 {
 /**
  * \brief A structure that holds the constructor parameters for the
@@ -276,6 +276,6 @@ protected:
 
 };  // class RateBoundStatus
 
-}  // namespace rate_bound_status
+}  // namespace custom_diagnostic_tasks
 
 #endif  // RATE_BOUND_STATUS_HPP_

--- a/include/v4l2_camera/rate_bound_status.hpp
+++ b/include/v4l2_camera/rate_bound_status.hpp
@@ -203,7 +203,7 @@ private:
 
     std::stringstream ss;
     ss << std::fixed << std::setprecision(2) << frequency_.value_or(0.0);
-    stat.add("Image publish rate", ss.str());
+    stat.add("Publish rate", ss.str());
 
     ss.str("");  // reset contents
     ss << get_level_string(get_level(frame_result));
@@ -224,6 +224,14 @@ private:
     ss.str("");  // reset contents
     ss << std::fixed << std::setprecision(2) << warn_params_.max_frequency;
     stat.add("Maximum WARN rate threshold", ss.str());
+
+    ss.str("");  // reset contents
+    ss << get_num_observation(candidate_state_);
+    stat.add("Observed frames", ss.str());
+
+    ss.str("");  // reset contents
+    ss << num_frame_transition_;
+    stat.add("Observed frames transition threshold", ss.str());
   }
 
 protected:

--- a/include/v4l2_camera/rate_bound_status.hpp
+++ b/include/v4l2_camera/rate_bound_status.hpp
@@ -16,15 +16,18 @@
 #define RATE_BOUND_STATUS_HPP_
 
 #include <diagnostic_updater/diagnostic_updater.hpp>
+
 #include <diagnostic_msgs/msg/diagnostic_status.hpp>
 
-#include <iomanip>
-#include <sstream>
-#include <variant>
-#include <optional>
-#include <mutex>
-#include <stdexcept>
 #include <chrono>
+#include <iomanip>
+#include <limits>
+#include <mutex>
+#include <optional>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <variant>
 
 namespace custom_diagnostic_tasks
 {
@@ -123,8 +126,8 @@ private:
     }
 
     // Confirm `warn_params` surely has wider range than `ok_params`
-    if (!(warn_params_.min_frequency < ok_params_.min_frequency &&
-          ok_params_.max_frequency< warn_params_.max_frequency)) {
+    if (warn_params_.min_frequency >= ok_params_.min_frequency ||
+      ok_params_.max_frequency >= warn_params_.max_frequency) {
       throw std::runtime_error(
           "Invalid range parameters were detected. warn_params should specify a range "
           "that includes a range of ok_params.");

--- a/include/v4l2_camera/rate_bound_status.hpp
+++ b/include/v4l2_camera/rate_bound_status.hpp
@@ -63,28 +63,28 @@ private:
   {
     Stale()
         : StateBase(diagnostic_msgs::msg::DiagnosticStatus::STALE,
-                    "topic has not been received yet.") {}
+                    "Topic has not been received yet") {}
   };
 
   struct Ok : public StateBase
   {
     Ok()
         : StateBase(diagnostic_msgs::msg::DiagnosticStatus::OK,
-                    "rate is reasonable.") {}
+                    "Rate is reasonable") {}
   };
 
   struct Warn : public StateBase
   {
     Warn()
         : StateBase(diagnostic_msgs::msg::DiagnosticStatus::WARN,
-                    "rate is within warning range.") {}
+                    "Rate is within warning range") {}
   };
 
   struct Error : public StateBase
   {
     Error()
         : StateBase(diagnostic_msgs::msg::DiagnosticStatus::ERROR,
-                    "rate is out of valid range.") {}
+                    "Rate is out of valid range") {}
   };
 
   using StateHolder = std::variant<Stale, Ok, Warn, Error>;
@@ -149,9 +149,6 @@ private:
 
     // If the classify result is same as previous one, count the number of observation
     // Otherwise, update candidate
-    std::cerr << "candidate_state_: " << candidate_state_.index() << ", "
-              << "frame_result: " << frame_result.index() << ", "
-              << "current_state_: " << current_state_.index() << std::endl;
     if (candidate_state_.index() == frame_result.index()) {  // if result has the same status as candidate
       std::visit([](auto& s){
         s.num_observation += 1;

--- a/include/v4l2_camera/rate_bound_status.hpp
+++ b/include/v4l2_camera/rate_bound_status.hpp
@@ -15,15 +15,14 @@
 #ifndef V4L2_CAMERA__RATE_BOUND_STATUS_HPP_
 #define V4L2_CAMERA__RATE_BOUND_STATUS_HPP_
 
-#include <diagnostic_msgs/msg/detail/diagnostic_status__struct.hpp>
 #include <diagnostic_updater/diagnostic_updater.hpp>
 #include <diagnostic_msgs/msg/diagnostic_status.hpp>
 
 #include <iomanip>
 #include <sstream>
-#include <type_traits>
 #include <variant>
 #include <optional>
+#include <mutex>
 
 namespace v4l2_camera
 {

--- a/include/v4l2_camera/rate_bound_status.hpp
+++ b/include/v4l2_camera/rate_bound_status.hpp
@@ -102,9 +102,9 @@ private:
    * transition. E.g., the status will not be changed from OK to WARN until successive
    * `num_frame_transition` WARNs are observed.
    * \param immediate_error_report If true (default), errors related to the rate bounds will be
-   * reported immediately once it is observed; otherwise, hysteresis manner using
+   * reported immediately once observed; otherwise, the hysteresis damping method using
    * `num_frame_transition` will be adopted
-   * \param name The arbitral string to be assigned for this diagnostic task.
+   * \param name The arbitrary string to be assigned for this diagnostic task.
    * This name will not be exposed in the actual published topics.
    */
   RateBoundStatus(const RateBoundStatusParam& ok_params,
@@ -125,7 +125,7 @@ private:
     if (!(warn_params_.min_frequency < ok_params_.min_frequency &&
           ok_params_.max_frequency< warn_params_.max_frequency)) {
       throw std::runtime_error(
-          "Invald range parameters were detected. warn_params should specify a range "
+          "Invalid range parameters were detected. warn_params should specify a range "
           "that includes a range of ok_params.");
     }
   }
@@ -148,7 +148,7 @@ private:
     } else {
       zero_seen_ = false;
       double delta = stamp - previous_frame_timestamp_.value();
-      frequency_ = (delta < 10*std::numeric_limits<double>::epsilon()) ?
+      frequency_ = (delta < 10 * std::numeric_limits<double>::epsilon()) ?
                    std::numeric_limits<double>::infinity() : 1. / delta;
     }
     previous_frame_timestamp_ = stamp;

--- a/include/v4l2_camera/rate_bound_status.hpp
+++ b/include/v4l2_camera/rate_bound_status.hpp
@@ -91,9 +91,20 @@ private:
   using StateHolder = std::variant<Stale, Ok, Warn, Error>;
 
  public:
+  /**
+   * \brief Constructs RateBoundstatus, which inherits diagnostic_updater::DiagnosticTask.
+   *
+   * \param ok_params The pair of min/max frequency for the topic rate to be recognized as "OK".
+   * \param warn_params The pair of min/max frequency for the topic rate to be recognized as "WARN".
+   * \param num_frame_transition The number of the successive observations for the status
+   * transition. E.g., the status will not be changed from OK to WARN until successive
+   * `num_frame_transition` WARNs are observed.
+   * \param name The arbitral string to be assigned for this diagnostic task.
+   * This name will not be exposed in the actual published topics.
+   */
   RateBoundStatus(const RateBoundStatusParam& ok_params,
                   const RateBoundStatusParam& warn_params,
-                  const size_t num_frame_transition,
+                  const size_t num_frame_transition = 1,
                   std::string name = "rate bound check")
       : DiagnosticTask(name), ok_params_(ok_params), warn_params_(warn_params),
         num_frame_transition_(num_frame_transition), zero_seen_(false),

--- a/include/v4l2_camera/rate_bound_status.hpp
+++ b/include/v4l2_camera/rate_bound_status.hpp
@@ -202,20 +202,28 @@ private:
     stat.summary(get_level(current_state_), get_msg(current_state_));
 
     std::stringstream ss;
-    ss << "observed=" << std::fixed << std::setprecision(2) << frequency_.value_or(0.0)
-       << ", level=" << get_level_string(get_level(frame_result));
-    stat.add("rate", ss.str());
+    ss << std::fixed << std::setprecision(2) << frequency_.value_or(0.0);
+    stat.add("Image publish rate", ss.str());
 
-    ss.str("");  // reset contents;
-    ss << std::fixed << std::setprecision(2)
-       << "OK(" << ok_params_.min_frequency << ", " << ok_params_.max_frequency << "), "
-       << "WARN[" << warn_params_.min_frequency << ", " << warn_params_.max_frequency << "]";
-    stat.add("rate criteria", ss.str());
+    ss.str("");  // reset contents
+    ss << get_level_string(get_level(frame_result));
+    stat.add("Rate status", ss.str());
 
-    ss.str("");  // reset contents;
-    ss << "level=" << get_level_string(get_level(candidate_state_))
-       << " (num observation=" << get_num_observation(candidate_state_) << ")";
-    stat.add("rate state next candidate", ss.str());
+    ss.str("");  // reset contents
+    ss << std::fixed << std::setprecision(2) << ok_params_.min_frequency;
+    stat.add("Minimum OK rate threshold", ss.str());
+
+    ss.str("");  // reset contents
+    ss << std::fixed << std::setprecision(2) << ok_params_.max_frequency;
+    stat.add("Maximum OK rate threshold", ss.str());
+
+    ss.str("");  // reset contents
+    ss << std::fixed << std::setprecision(2) << warn_params_.min_frequency;
+    stat.add("Minimum WARN rate threshold", ss.str());
+
+    ss.str("");  // reset contents
+    ss << std::fixed << std::setprecision(2) << warn_params_.max_frequency;
+    stat.add("Maximum WARN rate threshold", ss.str());
   }
 
 protected:

--- a/include/v4l2_camera/rate_bound_status.hpp
+++ b/include/v4l2_camera/rate_bound_status.hpp
@@ -1,0 +1,208 @@
+// Copyright 2025 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef V4L2_CAMERA__RATE_BOUND_STATUS_HPP_
+#define V4L2_CAMERA__RATE_BOUND_STATUS_HPP_
+
+#include <diagnostic_msgs/msg/detail/diagnostic_status__struct.hpp>
+#include <diagnostic_updater/diagnostic_updater.hpp>
+#include <diagnostic_msgs/msg/diagnostic_status.hpp>
+
+#include <type_traits>
+#include <variant>
+#include <optional>
+
+namespace v4l2_camera
+{
+/**
+ * \brief A structure that holds the constructor parameters for the
+ * RateBoundStatus class.
+ */
+struct RateBoundStatusParam
+{
+  RateBoundStatusParam(const double min_freq, const double max_freq)
+      : min_frequency(min_freq), max_frequency(max_freq){}
+
+  double min_frequency;
+  double max_frequency;
+};
+
+/**
+ * \brief Diagnostic task to monitor the interval between events.
+ *
+ * This diagnostic task monitors the difference between consecutive events,
+ * and creates corresponding diagnostics. This task categorize observed intervals into
+ * OK/WARN/ERROR according to the value ranges passed via constructor arguments
+ */
+class RateBoundStatus : public diagnostic_updater::DiagnosticTask
+{
+private:
+  // Helper struct to express state machine nodes
+  struct StateBase
+  {
+    StateBase(const unsigned char lv, const std::string m)
+        : level(lv), num_observation(0), msg(m) {}
+
+    unsigned char level;
+    size_t num_observation;
+    std::string msg;
+  };
+
+  struct Stale : public StateBase
+  {
+    Stale()
+        : StateBase(diagnostic_msgs::msg::DiagnosticStatus::STALE,
+                    "topic has not been received yet.") {}
+  };
+
+  struct Ok : public StateBase
+  {
+    Ok()
+        : StateBase(diagnostic_msgs::msg::DiagnosticStatus::OK,
+                    "rate is reasonable.") {}
+  };
+
+  struct Warn : public StateBase
+  {
+    Warn()
+        : StateBase(diagnostic_msgs::msg::DiagnosticStatus::WARN,
+                    "rate is within warning range.") {}
+  };
+
+  struct Error : public StateBase
+  {
+    Error()
+        : StateBase(diagnostic_msgs::msg::DiagnosticStatus::ERROR,
+                    "rate is out of valid range.") {}
+  };
+
+  using StateHolder = std::variant<Stale, Ok, Warn, Error>;
+
+ public:
+  RateBoundStatus(const RateBoundStatusParam& ok_params,
+                  const RateBoundStatusParam& warn_params,
+                  const size_t num_frame_transition,
+                  std::string name = "rate bound check")
+      : DiagnosticTask(name), ok_params_(ok_params), warn_params_(warn_params),
+        num_frame_transition_(num_frame_transition), zero_seen_(false),
+        candidate_state_(Stale{}), current_state_(Stale{})
+  {}
+
+  /**
+   * \brief Signals an event.
+   *
+   * \param t The timestamp of the event that will be used in computing
+   * intervals.
+   */
+  void tick(double stamp)
+  {
+    std::unique_lock<std::mutex> lock(lock_);
+    if (!previous_frame_timestamp_) {
+      previous_frame_timestamp_ = rclcpp::Clock().now().seconds();
+    }
+
+    if (stamp == 0) {
+      zero_seen_ = true;
+    } else {
+      zero_seen_ = false;
+      double delta = stamp - previous_frame_timestamp_.value();
+      frequency_ = (delta < 10*std::numeric_limits<double>::epsilon()) ?
+                   std::numeric_limits<double>::infinity() : 1. / delta;
+    }
+    previous_frame_timestamp_ = stamp;
+  }
+
+  void tick(const rclcpp::Time& t) {tick(t.seconds());}
+
+  /**
+   * \brief function called every update
+   */
+  virtual void run(diagnostic_updater::DiagnosticStatusWrapper& stat)
+  {
+    std::unique_lock<std::mutex> lock(lock_);
+
+    // classify the current observation
+    StateHolder frame_result;
+    if (!frequency_ || zero_seen_) {
+      frame_result.emplace<Stale>();
+    } else {
+      if (ok_params_.min_frequency < frequency_ && frequency_ < ok_params_.max_frequency) {
+        frame_result.emplace<Ok>();
+      } else if ((warn_params_.min_frequency <= frequency_ && frequency_ <= ok_params_.min_frequency) ||
+                 (ok_params_.max_frequency <= frequency_ && frequency_ <= warn_params_.max_frequency)) {
+        frame_result.emplace<Warn>();
+      } else {
+        frame_result.emplace<Error>();
+      }
+    }
+
+    // If the classify result is same as previous one, count the number of observation
+    // Otherwise, update candidate
+    std::cerr << "candidate_state_: " << candidate_state_.index() << ", "
+              << "frame_result: " << frame_result.index() << ", "
+              << "current_state_: " << current_state_.index() << std::endl;
+    if (candidate_state_.index() == frame_result.index()) {  // if result has the same status as candidate
+      std::visit([](auto& s){
+        s.num_observation += 1;
+      }, candidate_state_);
+    } else {
+      candidate_state_ = frame_result;
+    }
+
+    // Update the current state if the same state is observed multiple times
+    if (get_num_observation(candidate_state_) >= num_frame_transition_) {
+      current_state_ = candidate_state_;
+      std::visit([](auto& s) {
+        s.num_observation = 0;
+      }, candidate_state_);
+    }
+
+    stat.summary(get_level(current_state_), get_msg(current_state_));
+    stat.addf("Criteria", "OK(%.2f, %.2f), WARN[%.2f, %.2f]",
+              ok_params_.min_frequency, ok_params_.max_frequency,
+              warn_params_.min_frequency, warn_params_.max_frequency);
+
+    stat.addf("Observation", "level=%hhu, freq=%.2f", get_level(frame_result), frequency_); // NOTE: keep this variable order or level may visualized with wrong value
+    stat.addf("Next state candidate", "level=%hhu (num observation=%d)",
+              get_level(candidate_state_), get_num_observation(candidate_state_));
+  }
+
+protected:
+  RateBoundStatusParam ok_params_;
+  RateBoundStatusParam warn_params_;
+  size_t num_frame_transition_;
+  bool zero_seen_;
+  std::optional<double> frequency_;
+  std::optional<double> previous_frame_timestamp_;
+  std::mutex lock_;
+
+  StateHolder candidate_state_;
+  StateHolder current_state_;
+
+  unsigned char get_level(const StateHolder& state) {
+    return std::visit([](const auto& s){return s.level;}, state);
+  }
+
+  size_t get_num_observation(const StateHolder& state) {
+    return std::visit([](const auto& s){return s.num_observation;}, state);
+  }
+
+  std::string get_msg(const StateHolder& state) {
+    return std::visit([](const auto& s){return s.msg;}, state);
+  }
+};  // class RateBoundStatus
+
+}  // namespace v4l2_camera
+
+#endif  // V4L2_CAMERA__RATE_BOUND_STATUS_HPP_

--- a/include/v4l2_camera/rate_bound_status.hpp
+++ b/include/v4l2_camera/rate_bound_status.hpp
@@ -129,7 +129,7 @@ private:
   /**
    * \brief function called every update
    */
-  virtual void run(diagnostic_updater::DiagnosticStatusWrapper& stat)
+  void run(diagnostic_updater::DiagnosticStatusWrapper& stat) override
   {
     std::unique_lock<std::mutex> lock(lock_);
 

--- a/include/v4l2_camera/rate_bound_status.hpp
+++ b/include/v4l2_camera/rate_bound_status.hpp
@@ -145,14 +145,10 @@ private:
         std::chrono::steady_clock::now().time_since_epoch()).count();
 
     if (!previous_frame_timestamp_) {
-      previous_frame_timestamp_ = stamp;
-    }
-
-    double delta = stamp - previous_frame_timestamp_.value();
-    if (delta == 0) {
       zero_seen_ = true;
     } else {
       zero_seen_ = false;
+      double delta = stamp - previous_frame_timestamp_.value();
       frequency_ = (delta < 10 * std::numeric_limits<double>::epsilon()) ?
                    std::numeric_limits<double>::infinity() : 1. / delta;
     }

--- a/include/v4l2_camera/rate_bound_status.hpp
+++ b/include/v4l2_camera/rate_bound_status.hpp
@@ -246,19 +246,19 @@ protected:
   StateHolder candidate_state_;
   StateHolder current_state_;
 
-  unsigned char get_level(const StateHolder& state) {
+  static unsigned char get_level(const StateHolder& state) {
     return std::visit([](const auto& s){return s.level;}, state);
   }
 
-  size_t get_num_observation(const StateHolder& state) {
+  static size_t get_num_observation(const StateHolder& state) {
     return std::visit([](const auto& s){return s.num_observation;}, state);
   }
 
-  std::string get_msg(const StateHolder& state) {
+  static std::string get_msg(const StateHolder& state) {
     return std::visit([](const auto& s){return s.msg;}, state);
   }
 
-  std::string get_level_string(unsigned char level) {
+  static std::string get_level_string(unsigned char level) {
     switch(level) {
       case diagnostic_msgs::msg::DiagnosticStatus::OK:
         return "OK";

--- a/include/v4l2_camera/rate_bound_status.hpp
+++ b/include/v4l2_camera/rate_bound_status.hpp
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef V4L2_CAMERA__RATE_BOUND_STATUS_HPP_
-#define V4L2_CAMERA__RATE_BOUND_STATUS_HPP_
+#ifndef RATE_BOUND_STATUS_HPP_
+#define RATE_BOUND_STATUS_HPP_
 
 #include <diagnostic_updater/diagnostic_updater.hpp>
 #include <diagnostic_msgs/msg/diagnostic_status.hpp>
@@ -24,7 +24,7 @@
 #include <optional>
 #include <mutex>
 
-namespace v4l2_camera
+namespace rate_bound_status
 {
 /**
  * \brief A structure that holds the constructor parameters for the
@@ -237,6 +237,6 @@ protected:
 
 };  // class RateBoundStatus
 
-}  // namespace v4l2_camera
+}  // namespace rate_bound_status
 
-#endif  // V4L2_CAMERA__RATE_BOUND_STATUS_HPP_
+#endif  // RATE_BOUND_STATUS_HPP_

--- a/include/v4l2_camera/v4l2_camera.hpp
+++ b/include/v4l2_camera/v4l2_camera.hpp
@@ -132,8 +132,10 @@ private:
   std::shared_ptr<diagnostic_updater::FunctionDiagnosticTask> device_node_existence_diag_;
 
   std::optional<TimePerFrame> time_per_frame_;
-  std::optional<double> ok_range_ratio_;
-  std::optional<double> warn_range_ratio_;
+  std::optional<double> min_ok_rate_;
+  std::optional<double> max_ok_rate_;
+  std::optional<double> min_warn_rate_;
+  std::optional<double> max_warn_rate_;
   int num_frames_transition_;
 
   std::mutex lock_;

--- a/include/v4l2_camera/v4l2_camera.hpp
+++ b/include/v4l2_camera/v4l2_camera.hpp
@@ -20,6 +20,7 @@
 
 #include <camera_info_manager/camera_info_manager.hpp>
 #include <image_transport/image_transport.hpp>
+#include <diagnostic_updater/diagnostic_updater.hpp>
 
 #include <ostream>
 #include <rclcpp/rclcpp.hpp>

--- a/include/v4l2_camera/v4l2_camera.hpp
+++ b/include/v4l2_camera/v4l2_camera.hpp
@@ -30,6 +30,7 @@
 #include <string>
 #include <map>
 #include <vector>
+#include <optional>
 
 #include "v4l2_camera/visibility_control.h"
 
@@ -120,6 +121,12 @@ private:
 
   bool publish_next_frame_;
   bool use_image_transport_;
+
+  std::shared_ptr<diagnostic_updater::Updater> diag_updater_;
+  std::optional<TimePerFrame> time_per_frame_;
+  std::optional<double> ok_range_ratio_;
+  std::optional<double> warn_range_ratio_;
+  int num_frames_transition_;
 
 #ifdef ENABLE_CUDA
   // Memory region to communicate with GPU

--- a/include/v4l2_camera/v4l2_camera.hpp
+++ b/include/v4l2_camera/v4l2_camera.hpp
@@ -31,6 +31,8 @@
 #include <map>
 #include <vector>
 #include <optional>
+#include <mutex>
+
 
 #include "v4l2_camera/visibility_control.h"
 
@@ -123,10 +125,18 @@ private:
   bool use_image_transport_;
 
   std::shared_ptr<diagnostic_updater::Updater> diag_updater_;
+  std::shared_ptr<diagnostic_updater::CompositeDiagnosticTask> diag_composer_;
+
+  // To keep publishing diagnostics even after the constuctor of V4L2Camera class fail,
+  // this FunctionDiagnosticTask should be declared as a class member due to lifetime
+  std::shared_ptr<diagnostic_updater::FunctionDiagnosticTask> device_node_existence_diag_;
+
   std::optional<TimePerFrame> time_per_frame_;
   std::optional<double> ok_range_ratio_;
   std::optional<double> warn_range_ratio_;
   int num_frames_transition_;
+
+  std::mutex lock_;
 
 #ifdef ENABLE_CUDA
   // Memory region to communicate with GPU

--- a/include/v4l2_camera/v4l2_camera.hpp
+++ b/include/v4l2_camera/v4l2_camera.hpp
@@ -136,7 +136,7 @@ private:
   std::optional<double> max_ok_rate_;
   std::optional<double> min_warn_rate_;
   std::optional<double> max_warn_rate_;
-  int num_frames_transition_;
+  int observed_frames_transition_;
 
   std::mutex lock_;
 

--- a/include/v4l2_camera/v4l2_camera_device.hpp
+++ b/include/v4l2_camera/v4l2_camera_device.hpp
@@ -86,7 +86,7 @@ public:
 
   void setTSCOffset();
 
-  sensor_msgs::msg::Image::UniquePtr capture();
+  std::tuple<sensor_msgs::msg::Image::UniquePtr, bool> capture();
 
 private:
   /// Image buffer

--- a/include/v4l2_camera/v4l2_camera_device.hpp
+++ b/include/v4l2_camera/v4l2_camera_device.hpp
@@ -23,6 +23,7 @@
 #include <utility>
 #include <tuple>
 #include <vector>
+#include <optional>
 
 #include "v4l2_camera/control.hpp"
 #include "v4l2_camera/image_format.hpp"
@@ -86,7 +87,17 @@ public:
 
   void setTSCOffset();
 
-  std::tuple<sensor_msgs::msg::Image::UniquePtr, bool> capture();
+  /**
+   * This function returns:
+   * - unique pointer for captured image
+   * - bool value to show V4L2_BUF_FLAG_ERROR is set to dequeued buffer
+   * - sequence number
+   * - raw buffer timestamp
+   * all items other than image are for monitoring stream correctness 
+   */
+  std::tuple<sensor_msgs::msg::Image::UniquePtr, bool, std::optional<uint32_t>,
+             std::optional<timeval>>
+  capture();
 
 private:
   /// Image buffer

--- a/package.xml
+++ b/package.xml
@@ -20,7 +20,8 @@
   <depend>sensor_msgs</depend>
   <depend>image_transport</depend>
   <depend>camera_info_manager</depend>
-  
+  <depend>diagnostic_updater</depend>
+
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
 

--- a/src/v4l2_camera.cpp
+++ b/src/v4l2_camera.cpp
@@ -113,9 +113,9 @@ static void diagnoseStreamLiveness(
     max_timestamp_value = raw_timestamp_value;
   }
 
-  stat.addf("sequence", "observed=%u, current_max=%u", sequence, max_sequence_value);
-  stat.addf("raw_timestamp", "observed=%lu, current_max=%lu",
-            raw_timestamp_value, max_timestamp_value);
+  stat.addf("Sequence", "%u", sequence);
+  stat.addf("Raw timestamp", "%lu", raw_timestamp_value);
+
 }  // static void diagnoseStreamLiveness
 
 V4L2Camera::V4L2Camera(rclcpp::NodeOptions const & options)

--- a/src/v4l2_camera.cpp
+++ b/src/v4l2_camera.cpp
@@ -203,10 +203,9 @@ V4L2Camera::V4L2Camera(rclcpp::NodeOptions const & options)
       auto max_ok_frequency = target_frequency * (1.0 + ok_range_ratio_.value());
       auto min_warn_frequency = target_frequency * (1.0 - warn_range_ratio_.value());
       auto max_warn_frequency = target_frequency * (1.0 + warn_range_ratio_.value());
-      RateBoundStatus rate_bound_status(
-          RateBoundStatusParam(min_ok_frequency, max_ok_frequency),
-          RateBoundStatusParam(min_warn_frequency, max_warn_frequency),
-          static_cast<size_t>(num_frames_transition_),
+      rate_bound_status::RateBoundStatus rate_bound_status(
+          rate_bound_status::RateBoundStatusParam(min_ok_frequency, max_ok_frequency),
+          rate_bound_status::RateBoundStatusParam(min_warn_frequency, max_warn_frequency),
           "rate bound check");
       diag_composer_->addTask(&rate_bound_status);
 

--- a/src/v4l2_camera.cpp
+++ b/src/v4l2_camera.cpp
@@ -172,7 +172,7 @@ V4L2Camera::V4L2Camera(rclcpp::NodeOptions const & options)
   max_ok_rate_ = declare_parameter<double>("max_ok_rate", 11.0);
   min_warn_rate_ = declare_parameter<double>("min_warn_rate", 8.0);
   max_warn_rate_ = declare_parameter<double>("max_warn_rate", 12.0);
-  num_frames_transition_ = declare_parameter<int>("num_frames_transition", 3);
+  observed_frames_transition_ = declare_parameter<int>("observed_frames_transition", 3);
 
   diag_updater_ = std::make_shared<diagnostic_updater::Updater>(this);
   diag_updater_->setHardwareID(hardware_id.empty() ? "none" : hardware_id);
@@ -222,7 +222,7 @@ V4L2Camera::V4L2Camera(rclcpp::NodeOptions const & options)
       custom_diagnostic_tasks::RateBoundStatus rate_bound_status(
           custom_diagnostic_tasks::RateBoundStatusParam(min_ok_rate_.value(), max_ok_rate_.value()),
           custom_diagnostic_tasks::RateBoundStatusParam(min_warn_rate_.value(), max_warn_rate_.value()),
-          static_cast<size_t>(num_frames_transition_), true,
+          static_cast<size_t>(observed_frames_transition_), true,
           "rate bound check");
       diag_composer_->addTask(&rate_bound_status);
 

--- a/src/v4l2_camera.cpp
+++ b/src/v4l2_camera.cpp
@@ -219,9 +219,9 @@ V4L2Camera::V4L2Camera(rclcpp::NodeOptions const & options)
       }
 
       // Setup diagnostics
-      rate_bound_status::RateBoundStatus rate_bound_status(
-          rate_bound_status::RateBoundStatusParam(min_ok_rate_.value(), max_ok_rate_.value()),
-          rate_bound_status::RateBoundStatusParam(min_warn_rate_.value(), max_warn_rate_.value()),
+      custom_diagnostic_tasks::RateBoundStatus rate_bound_status(
+          custom_diagnostic_tasks::RateBoundStatusParam(min_ok_rate_.value(), max_ok_rate_.value()),
+          custom_diagnostic_tasks::RateBoundStatusParam(min_warn_rate_.value(), max_warn_rate_.value()),
           static_cast<size_t>(num_frames_transition_), true,
           "rate bound check");
       diag_composer_->addTask(&rate_bound_status);

--- a/src/v4l2_camera.cpp
+++ b/src/v4l2_camera.cpp
@@ -295,8 +295,8 @@ V4L2Camera::V4L2Camera(rclcpp::NodeOptions const & options)
           image_pub_->publish(std::move(img));
           info_pub_->publish(std::move(ci));
         }
-        // Record the topic timestamp to monitor the interval diagnostics
-        rate_bound_status.tick(stamp);
+        // Record the current timestamp to monitor the interval diagnostics
+        rate_bound_status.tick();
       }
     }
   };

--- a/src/v4l2_camera.cpp
+++ b/src/v4l2_camera.cpp
@@ -206,6 +206,7 @@ V4L2Camera::V4L2Camera(rclcpp::NodeOptions const & options)
       rate_bound_status::RateBoundStatus rate_bound_status(
           rate_bound_status::RateBoundStatusParam(min_ok_frequency, max_ok_frequency),
           rate_bound_status::RateBoundStatusParam(min_warn_frequency, max_warn_frequency),
+          static_cast<size_t>(num_frames_transition_), true,
           "rate bound check");
       diag_composer_->addTask(&rate_bound_status);
 

--- a/src/v4l2_camera.cpp
+++ b/src/v4l2_camera.cpp
@@ -410,7 +410,7 @@ void V4L2Camera::createParameters()
   time_per_frame_descriptor.name = "time_per_frame";
   time_per_frame_descriptor.description = "Desired period between successive frames in seconds";
   time_per_frame_descriptor.additional_constraints =
-      "Length 2 array, with numerator(second) and denominator(frames)";
+      "Length 2 array, with numerator (second) and denominator (frames)";
   time_per_frame_ = declare_parameter<TimePerFrame>(
       "time_per_frame", {tpf.first, tpf.second},
       time_per_frame_descriptor);

--- a/src/v4l2_camera_device.cpp
+++ b/src/v4l2_camera_device.cpp
@@ -240,7 +240,7 @@ void V4l2CameraDevice::setTSCOffset()
   }
 }
 
-Image::UniquePtr V4l2CameraDevice::capture()
+std::tuple<Image::UniquePtr, bool> V4l2CameraDevice::capture()
 {
   auto buf = v4l2_buffer{};
   rclcpp::Time buf_stamp;
@@ -254,7 +254,7 @@ Image::UniquePtr V4l2CameraDevice::capture()
       rclcpp::get_logger("v4l2_camera"),
       "Error dequeueing buffer: %s (%s)", strerror(errno),
       std::to_string(errno).c_str());
-    return nullptr;
+    return {nullptr, true};
   }
 
   if (use_v4l2_buffer_timestamps_) {
@@ -276,13 +276,16 @@ Image::UniquePtr V4l2CameraDevice::capture()
   img->data.resize(cur_data_format_.imageByteSize);
   std::copy(buffer.start, buffer.start + img->data.size(), img->data.begin());
 
+  // Check whether V4L2_BUF_FLAG_ERROR is set in v4l2_buffer.flags
+  bool is_v4l2_buffer_flag_error_detected = (buf.flags & V4L2_BUF_FLAG_ERROR);
+
   // Requeue buffer to be reused for new captures
   if (-1 == ioctl(fd_, VIDIOC_QBUF, &buf)) {
     RCLCPP_ERROR(
       rclcpp::get_logger("v4l2_camera"),
       "Error re-queueing buffer: %s (%s)", strerror(errno),
       std::to_string(errno).c_str());
-    return nullptr;
+    return {nullptr, is_v4l2_buffer_flag_error_detected};
   }
 
   // Fill in remaining image information
@@ -300,7 +303,7 @@ Image::UniquePtr V4l2CameraDevice::capture()
     RCLCPP_WARN(rclcpp::get_logger("v4l2_camera"), "Current pixel format is not supported yet");
   }
 
-  return img;
+  return std::make_tuple(std::move(img), is_v4l2_buffer_flag_error_detected);
 }
 
 int32_t V4l2CameraDevice::getControlValue(uint32_t id)


### PR DESCRIPTION
This PR adds diagnosis features to monitor camera behavior. The handled features include:

| feature               | description                                                                                                                                                              |
|:----------------------|:-------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
| rate status           | check if the current topic rate fulfills criteria specified by `(min_max)_(ok|warn)_rate`                                                                                |
| device node existence | check if the device node specified via the `video_device` parameter is available on streaming start. If not, emit ERROR status                                           |
| buffer flag           | check whether `V4L2_BUF_FLAG_ERROR` is set to dequeued `v4l2_buffer`. According to the flag description, the dequeued data might have been corrupted if this flag is set |
| stream liveness       | check if `sequence` and `timestamp` are monotonically increasing between frames                                                                                          |

## How to test this PR
- run `v4l2_camera`
```bash
ros2 run v4l2_camera v4l2_camera_node --ros-args -p hardware_id:=camera0 -p time_per_frame:="[1, 10]"
```

- Check the diagnostics
```bash
ros2 topic echo /diagnostics
# or
ros2 run rqt_runtime_monitor rqt_runtime_monitor
```


The `/diagnostics` contents looks like:
```bash
---
header:
  stamp:
    sec: 1747829438
    nanosec: 60570906
  frame_id: ''
status:
- level: "\0"
  name: 'v4l2_camera: camera0_diagnostics'
  message: ''
  hardware_id: camera0
  values:
  - key: Device node existence
    value: OK
  - key: Publish rate
    value: '10.43'
  - key: Rate status
    value: OK
  - key: Minimum OK rate threshold
    value: '9.00'
  - key: Maximum OK rate threshold
    value: '11.00'
  - key: Minimum WARN rate threshold
    value: '8.00'
  - key: Maximum WARN rate threshold
    value: '12.00'
  - key: Observed frames
    value: '1'
  - key: Observed frames transition threshold
    value: '3'
  - key: Buffer flag status
    value: OK
  - key: Stream liveness
    value: OK
  - key: Sequence
    value: '61'
  - key: Raw timestamp
    value: '40120309924000'
---
```
![Screenshot from 2025-05-21 21-10-38](https://github.com/user-attachments/assets/62acf098-a520-4180-aa59-08dbcf3f9f6b)
