### PR TITLE
fix: check the latest update to validate stream liveness in rate_bound_status

### DIFF
--- a/src/v4l2_camera.cpp
+++ b/src/v4l2_camera.cpp
@@ -220,6 +220,7 @@ V4L2Camera::V4L2Camera(rclcpp::NodeOptions const & options)
 
       // Setup diagnostics
       custom_diagnostic_tasks::RateBoundStatus rate_bound_status(
+          this,
           custom_diagnostic_tasks::RateBoundStatusParam(min_ok_rate_.value(), max_ok_rate_.value()),
           custom_diagnostic_tasks::RateBoundStatusParam(min_warn_rate_.value(), max_warn_rate_.value()),
           static_cast<size_t>(observed_frames_transition_), true,


### PR DESCRIPTION
This PR fixes the problem reported [here](https://github.com/tier4/ros2_v4l2_camera/pull/29#issuecomment-2903385476): where the rate_bound_status will not go `ERROR` when the stream stops completely.

If the stream stops completely, the modification of this PR increments `num_frame_skipped` for every `1. / warn_params_.min_frequency` second (i.e., it assumes at least `num_frame_skipped` frames were lost since the stream stopped).  Once the `num_frame_skipped` exceeds the transition threshold, then the current current statte will be updated.

This PR also adds an entry for diagnostics named `Assumed skipped frames` to avoid confusion;  the state transition happens based on `warn_params_.min_frequency` for the case of `immediate_error_report:=false`.

E.g., assuming the following conditions:
- sensor frame rate: 10Hz (but stream has been stopped completely for some reason) -> diagnostics will be updated at the same 10Hz
- warn_params_.min_frequency: 8Hz
- num_frame_transient: 4
- immediate_error_report: false (hysteresis is also applied to the error report)

In this case, it will take 500 [ms] (=5 update diagnostics) to transition the state to error since the stream stops.