### PR TITLE
feat(launch): expose diagnostic parameters in v4l2_camera launch file

### DIFF
--- a/launch/v4l2_camera.launch.py
+++ b/launch/v4l2_camera.launch.py
@@ -67,6 +67,7 @@ def launch_setup(context, *args, **kwargs):
             ],
             parameters=[
                 load_composable_node_param("v4l2_camera_param_path"),
+                load_composable_node_param("rate_diagnostics_param_path"),
                 {
                     "camera_info_url": LaunchConfiguration("camera_info_url"),
                     "use_sensor_data_qos": LaunchConfiguration("use_sensor_data_qos"),
@@ -74,11 +75,6 @@ def launch_setup(context, *args, **kwargs):
                     "use_v4l2_buffer_timestamps": LaunchConfiguration("use_v4l2_buffer_timestamps"),
                     "use_image_transport": LaunchConfiguration("use_image_transport"),
                     "hardware_id": LaunchConfiguration("camera_name"),
-                    "min_ok_rate": LaunchConfiguration("min_ok_rate"),
-                    "max_ok_rate": LaunchConfiguration("max_ok_rate"),
-                    "min_warn_rate": LaunchConfiguration("min_warn_rate"),
-                    "max_warn_rate": LaunchConfiguration("max_warn_rate"),
-                    "observed_frames_transition": LaunchConfiguration("observed_frames_transition"),
                 },
             ],
             extra_arguments=[{"use_intra_process_comms": LaunchConfiguration("use_intra_process")}],
@@ -124,6 +120,8 @@ def generate_launch_description():
                    description='namespace in which the nodes launched')
     add_launch_arg('v4l2_camera_param_path',
                    description='path to the yaml file that contains parameters for v4l2_camera node')
+    add_launch_arg('rate_diagnostics_param_path',
+                   description='path to the yaml file that contains parameters for rate diagnostics')
     add_launch_arg('camera_info_url',
                    description='url to the yaml file that contains camera\'s intrinsic paramters')
     add_launch_arg('use_intra_process', 'False',
@@ -140,16 +138,8 @@ def generate_launch_description():
                    'otherwise, will be the system time when the buffer is read')
     add_launch_arg('use_image_transport', 'true',
                    description='flag to launch image_transport node')
-    add_launch_arg('min_ok_rate', '9.0',
-                   description='Minimum frame rate to be considered as OK')
-    add_launch_arg('max_ok_rate', '11.0',
-                   description='Maximum frame rate to be considered as OK')
-    add_launch_arg('min_warn_rate', '8.0',
-                   description='Minimum frame rate to be considered as WARN')
-    add_launch_arg('max_warn_rate', '12.0',
-                   description='Maximum frame rate to be considered as WARN')
-    add_launch_arg('observed_frames_transition', '3',
-                   description='Number of frames to be observed before transition to the next state')
+    add_launch_arg('hardware_id',
+                   description='hardware id of the camera')
 
     return LaunchDescription(
         [

--- a/launch/v4l2_camera.launch.py
+++ b/launch/v4l2_camera.launch.py
@@ -73,6 +73,12 @@ def launch_setup(context, *args, **kwargs):
                     "publish_rate": LaunchConfiguration("publish_rate"),
                     "use_v4l2_buffer_timestamps": LaunchConfiguration("use_v4l2_buffer_timestamps"),
                     "use_image_transport": LaunchConfiguration("use_image_transport"),
+                    "hardware_id": LaunchConfiguration("camera_name"),
+                    "min_ok_rate": LaunchConfiguration("min_ok_rate"),
+                    "max_ok_rate": LaunchConfiguration("max_ok_rate"),
+                    "min_warn_rate": LaunchConfiguration("min_warn_rate"),
+                    "max_warn_rate": LaunchConfiguration("max_warn_rate"),
+                    "observed_frames_transition": LaunchConfiguration("observed_frames_transition"),
                 },
             ],
             extra_arguments=[{"use_intra_process_comms": LaunchConfiguration("use_intra_process")}],
@@ -134,6 +140,16 @@ def generate_launch_description():
                    'otherwise, will be the system time when the buffer is read')
     add_launch_arg('use_image_transport', 'true',
                    description='flag to launch image_transport node')
+    add_launch_arg('min_ok_rate', '9.0',
+                   description='Minimum frame rate to be considered as OK')
+    add_launch_arg('max_ok_rate', '11.0',
+                   description='Maximum frame rate to be considered as OK')
+    add_launch_arg('min_warn_rate', '8.0',
+                   description='Minimum frame rate to be considered as WARN')
+    add_launch_arg('max_warn_rate', '12.0',
+                   description='Maximum frame rate to be considered as WARN')
+    add_launch_arg('observed_frames_transition', '3',
+                   description='Number of frames to be observed before transition to the next state')
 
     return LaunchDescription(
         [

--- a/launch/v4l2_camera.launch.py
+++ b/launch/v4l2_camera.launch.py
@@ -74,7 +74,7 @@ def launch_setup(context, *args, **kwargs):
                     "publish_rate": LaunchConfiguration("publish_rate"),
                     "use_v4l2_buffer_timestamps": LaunchConfiguration("use_v4l2_buffer_timestamps"),
                     "use_image_transport": LaunchConfiguration("use_image_transport"),
-                    "hardware_id": LaunchConfiguration("camera_name"),
+                    "hardware_id": LaunchConfiguration("hardware_id"),
                 },
             ],
             extra_arguments=[{"use_intra_process_comms": LaunchConfiguration("use_intra_process")}],


### PR DESCRIPTION
This PR adds the new diagnostic parameters from #29  and #30 to the launch parameters of the launchfile.

| Added Parameter               | Default       |
|------------------------------|---------------|
| `hardware_id`                | `camera_name` |
| `min_ok_rate`                | 9.0         |
| `max_ok_rate`                | 11.0        |
| `min_warn_rate`              | 8.0         |
| `max_warn_rate`              | 12.0        |
| `observed_frames_transition`| 3           |