### PR TITLE
feat: update rate bound status

### DIFF
--- a/include/v4l2_camera/hysteresis_state_machine.hpp
+++ b/include/v4l2_camera/hysteresis_state_machine.hpp
@@ -43,7 +43,7 @@ struct Error : public StateBase
 
 using StateHolder = std::variant<Stale, Ok, Warn, Error>;
 
-static StateHolder generate_state(const DiagnosticStatus_t & state)
+static inline StateHolder generate_state(const DiagnosticStatus_t & state)
 {
   switch (state) {
     case diagnostic_msgs::msg::DiagnosticStatus::STALE:

--- a/include/v4l2_camera/hysteresis_state_machine.hpp
+++ b/include/v4l2_camera/hysteresis_state_machine.hpp
@@ -1,0 +1,167 @@
+#ifndef HYSTERESIS_STATE_MACHINE_HPP_
+#define HYSTERESIS_STATE_MACHINE_HPP_
+
+#include <tracetools/utils.hpp>
+
+#include <diagnostic_msgs/msg/diagnostic_status.hpp>
+
+#include <string>
+#include <variant>
+
+namespace custom_diagnostic_tasks
+{
+using DiagnosticStatus_t = unsigned char;
+
+// Helper struct to express state machine nodes
+struct StateBase
+{
+  StateBase(const DiagnosticStatus_t lv) : level(lv), num_observations(1) {}
+
+  DiagnosticStatus_t level;
+  size_t num_observations;
+};
+
+struct Stale : public StateBase
+{
+  Stale() : StateBase(diagnostic_msgs::msg::DiagnosticStatus::STALE) {}
+};
+
+struct Ok : public StateBase
+{
+  Ok() : StateBase(diagnostic_msgs::msg::DiagnosticStatus::OK) {}
+};
+
+struct Warn : public StateBase
+{
+  Warn() : StateBase(diagnostic_msgs::msg::DiagnosticStatus::WARN) {}
+};
+
+struct Error : public StateBase
+{
+  Error() : StateBase(diagnostic_msgs::msg::DiagnosticStatus::ERROR) {}
+};
+
+using StateHolder = std::variant<Stale, Ok, Warn, Error>;
+
+StateHolder generate_state(const DiagnosticStatus_t & state)
+{
+  switch (state) {
+    case diagnostic_msgs::msg::DiagnosticStatus::STALE:
+      return Stale{};
+    case diagnostic_msgs::msg::DiagnosticStatus::OK:
+      return Ok{};
+    case diagnostic_msgs::msg::DiagnosticStatus::WARN:
+      return Warn{};
+    case diagnostic_msgs::msg::DiagnosticStatus::ERROR:
+      return Error{};
+    default:
+      throw std::runtime_error("Undefined status");
+  }
+}
+
+static std::string get_level_string(DiagnosticStatus_t level) {
+  switch(level) {
+    case diagnostic_msgs::msg::DiagnosticStatus::OK:
+      return "OK";
+    case diagnostic_msgs::msg::DiagnosticStatus::WARN:
+      return "WARN";
+    case diagnostic_msgs::msg::DiagnosticStatus::ERROR:
+      return "ERROR";
+    case diagnostic_msgs::msg::DiagnosticStatus::STALE:
+      return "STALE";
+    default:
+      return "UNDEFINED";
+  }
+}
+
+static DiagnosticStatus_t get_level(const StateHolder & state)
+{
+  return std::visit([](const auto & s) { return s.level; }, state);
+}
+
+static size_t get_num_observations(const StateHolder & state)
+{
+  return std::visit([](const auto & s) { return s.num_observations; }, state);
+}
+
+class HysteresisStateMachine
+ {
+public:
+  /**
+   * \brief Constructs HysteresisStateMachine, which implements a smoothing
+            filter over observation
+   *
+   * \param num_frame_transition The number of the successive observations for
+            the status transition. E.g., the status will not be changed from OK
+to WARN until successive `num_frame_transition` WARNs are observed.
+   * \param immediate_error_report If true, errors will be reported immediately
+            once observed; otherwise, the hysteresis damping method using
+            `num_frame_transition` will be adopted
+   * \param immediate_relax_state if true, reported state will immediately
+            change if better state that the current one is observed
+   */
+  HysteresisStateMachine(
+    const size_t num_frame_transition = 1, const bool immediate_error_report = false,
+    const bool immediate_relax_state = true)
+  : num_frame_transition_(num_frame_transition),
+    immediate_error_report_(immediate_error_report),
+    immediate_relax_state_(immediate_relax_state)
+  {
+    if (num_frame_transition < 1) {
+      num_frame_transition_ = 1;
+    }
+  }
+
+  /**
+   * \bried update internal state and returns the filtered state
+   */
+  DiagnosticStatus_t update_state(const DiagnosticStatus_t &observation,
+                                  const DiagnosticStatus_t &current_level)
+  {
+    // If the classify result is same as previous one and the observation is
+    // different from the current one, increment the number of observation
+    // Otherwise, update candidate
+    auto candidate_level = get_level(candidate_state_);
+    if (candidate_level == observation && candidate_level != current_level) {
+      std::visit([](auto & s) { s.num_observations += 1; }, candidate_state_);
+    } else {
+      candidate_state_ = generate_state(observation);
+    }
+
+    // Update the current state if
+    // - immediate error report is required and the observed state is error
+    // - Or the same state is observed multiple times
+    // - Or the observed state has lower level than the current one (i.e., the state is improved)
+    bool is_immediate_error =
+      (immediate_error_report_ && std::holds_alternative<Error>(candidate_state_));
+    bool observed_over_threshold = (get_num_observations(candidate_state_) >= num_frame_transition_);
+    bool is_immediate_relax =
+        (immediate_relax_state_ && get_level(candidate_state_) < current_level);
+
+    DiagnosticStatus_t updated_level = current_level;
+    if (is_immediate_error || observed_over_threshold || is_immediate_relax) {
+      updated_level = get_level(candidate_state_);
+    }
+
+    return updated_level;
+  }
+
+  DiagnosticStatus_t get_candidate_level() {
+    return get_level(candidate_state_);
+  }
+
+  size_t get_candidate_num_observation() {
+    return get_num_observations(candidate_state_);
+  }
+
+protected:
+  size_t num_frame_transition_;
+  bool immediate_error_report_;
+  bool immediate_relax_state_;
+  StateHolder candidate_state_;
+
+};  // class HysteresisStateMachine
+
+}  // namespace custom_diagnostic_tasks
+
+#endif  // HYSTERESIS_STATE_MACHINE_HPP_

--- a/include/v4l2_camera/hysteresis_state_machine.hpp
+++ b/include/v4l2_camera/hysteresis_state_machine.hpp
@@ -15,7 +15,7 @@ using DiagnosticStatus_t = unsigned char;
 // Helper struct to express state machine nodes
 struct StateBase
 {
-  StateBase(const DiagnosticStatus_t lv) : level(lv), num_observations(1) {}
+  explicit StateBase(const DiagnosticStatus_t lv) : level(lv), num_observations(1) {}
 
   DiagnosticStatus_t level;
   size_t num_observations;
@@ -43,7 +43,7 @@ struct Error : public StateBase
 
 using StateHolder = std::variant<Stale, Ok, Warn, Error>;
 
-StateHolder generate_state(const DiagnosticStatus_t & state)
+static StateHolder generate_state(const DiagnosticStatus_t & state)
 {
   switch (state) {
     case diagnostic_msgs::msg::DiagnosticStatus::STALE:
@@ -100,7 +100,7 @@ to WARN until successive `num_frame_transition` WARNs are observed.
    * \param immediate_relax_state if true, reported state will immediately
             change if better state that the current one is observed
    */
-  HysteresisStateMachine(
+  explicit HysteresisStateMachine(
     const size_t num_frame_transition = 1, const bool immediate_error_report = false,
     const bool immediate_relax_state = true)
   : num_frame_transition_(num_frame_transition),
@@ -113,7 +113,7 @@ to WARN until successive `num_frame_transition` WARNs are observed.
   }
 
   /**
-   * \bried update internal state and returns the filtered state
+   * \brief update internal state and returns the filtered state
    */
   DiagnosticStatus_t update_state(const DiagnosticStatus_t &observation,
                                   const DiagnosticStatus_t &current_level)

--- a/include/v4l2_camera/hysteresis_state_machine.hpp
+++ b/include/v4l2_camera/hysteresis_state_machine.hpp
@@ -180,6 +180,12 @@ to WARN until successive `num_frame_transition` WARNs are observed.
   void set_current_state_level(const DiagnosticStatus_t & state) {
     current_state_ = generate_state(state);
   }
+
+  bool get_immediate_error_report_param() { return immediate_error_report_; }
+
+  bool get_immediate_relax_state_param() { return immediate_relax_state_; }
+
+
 protected:
   size_t num_frame_transition_;
   bool immediate_error_report_;

--- a/include/v4l2_camera/hysteresis_state_machine.hpp
+++ b/include/v4l2_camera/hysteresis_state_machine.hpp
@@ -1,3 +1,17 @@
+// Copyright 2025 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #ifndef HYSTERESIS_STATE_MACHINE_HPP_
 #define HYSTERESIS_STATE_MACHINE_HPP_
 
@@ -59,8 +73,9 @@ static inline StateHolder generate_state(const DiagnosticStatus_t & state)
   }
 }
 
-static std::string get_level_string(DiagnosticStatus_t level) {
-  switch(level) {
+static std::string get_level_string(DiagnosticStatus_t level)
+{
+  switch (level) {
     case diagnostic_msgs::msg::DiagnosticStatus::OK:
       return "OK";
     case diagnostic_msgs::msg::DiagnosticStatus::WARN:
@@ -85,7 +100,7 @@ static size_t get_num_observations(const StateHolder & state)
 }
 
 class HysteresisStateMachine
- {
+{
 public:
   /**
    * \brief Constructs HysteresisStateMachine, which implements a smoothing
@@ -105,7 +120,8 @@ to WARN until successive `num_frame_transition` WARNs are observed.
     const bool immediate_relax_state = true)
   : num_frame_transition_(num_frame_transition),
     immediate_error_report_(immediate_error_report),
-    immediate_relax_state_(immediate_relax_state)
+    immediate_relax_state_(immediate_relax_state),
+    current_state_(Stale{})
   {
     if (num_frame_transition < 1) {
       num_frame_transition_ = 1;
@@ -115,13 +131,13 @@ to WARN until successive `num_frame_transition` WARNs are observed.
   /**
    * \brief update internal state and returns the filtered state
    */
-  DiagnosticStatus_t update_state(const DiagnosticStatus_t &observation,
-                                  const DiagnosticStatus_t &current_level)
+  void update_state(const DiagnosticStatus_t& observation)
   {
     // If the classify result is same as previous one and the observation is
     // different from the current one, increment the number of observation
     // Otherwise, update candidate
     auto candidate_level = get_level(candidate_state_);
+    auto current_level = get_level(current_state_);
     if (candidate_level == observation && candidate_level != current_level) {
       std::visit([](auto & s) { s.num_observations += 1; }, candidate_state_);
     } else {
@@ -134,16 +150,17 @@ to WARN until successive `num_frame_transition` WARNs are observed.
     // - Or the observed state has lower level than the current one (i.e., the state is improved)
     bool is_immediate_error =
       (immediate_error_report_ && std::holds_alternative<Error>(candidate_state_));
-    bool observed_over_threshold = (get_num_observations(candidate_state_) >= num_frame_transition_);
+    bool observed_over_threshold =
+      (get_num_observations(candidate_state_) >= num_frame_transition_);
     bool is_immediate_relax =
-        (immediate_relax_state_ && get_level(candidate_state_) < current_level);
+      (immediate_relax_state_ && get_level(candidate_state_) < current_level);
 
     DiagnosticStatus_t updated_level = current_level;
     if (is_immediate_error || observed_over_threshold || is_immediate_relax) {
       updated_level = get_level(candidate_state_);
     }
 
-    return updated_level;
+    current_state_ = generate_state(updated_level);
   }
 
   DiagnosticStatus_t get_candidate_level() {
@@ -154,12 +171,21 @@ to WARN until successive `num_frame_transition` WARNs are observed.
     return get_num_observations(candidate_state_);
   }
 
+  size_t get_num_frame_transition() { return num_frame_transition_; }
+
+  DiagnosticStatus_t get_current_state_level() {
+    return get_level(current_state_);
+  }
+
+  void set_current_state_level(const DiagnosticStatus_t & state) {
+    current_state_ = generate_state(state);
+  }
 protected:
   size_t num_frame_transition_;
   bool immediate_error_report_;
   bool immediate_relax_state_;
   StateHolder candidate_state_;
-
+  StateHolder current_state_;
 };  // class HysteresisStateMachine
 
 }  // namespace custom_diagnostic_tasks

--- a/include/v4l2_camera/rate_bound_status.hpp
+++ b/include/v4l2_camera/rate_bound_status.hpp
@@ -30,6 +30,8 @@
 #include <string>
 #include <variant>
 
+#include <v4l2_camera/hysteresis_state_machine.hpp>
+
 namespace custom_diagnostic_tasks
 {
 /**
@@ -54,48 +56,6 @@ struct RateBoundStatusParam
  */
 class RateBoundStatus : public diagnostic_updater::DiagnosticTask
 {
-private:
-  // Helper struct to express state machine nodes
-  struct StateBase
-  {
-    StateBase(const unsigned char lv, const std::string m)
-        : level(lv), num_observations(1), msg(m) {}
-
-    unsigned char level;
-    size_t num_observations;
-    std::string msg;
-  };
-
-  struct Stale : public StateBase
-  {
-    Stale()
-        : StateBase(diagnostic_msgs::msg::DiagnosticStatus::STALE,
-                    "Topic has not been received yet") {}
-  };
-
-  struct Ok : public StateBase
-  {
-    Ok()
-        : StateBase(diagnostic_msgs::msg::DiagnosticStatus::OK,
-                    "Rate is reasonable") {}
-  };
-
-  struct Warn : public StateBase
-  {
-    Warn()
-        : StateBase(diagnostic_msgs::msg::DiagnosticStatus::WARN,
-                    "Rate is within warning range") {}
-  };
-
-  struct Error : public StateBase
-  {
-    Error()
-        : StateBase(diagnostic_msgs::msg::DiagnosticStatus::ERROR,
-                    "Rate is out of valid range") {}
-  };
-
-  using StateHolder = std::variant<Stale, Ok, Warn, Error>;
-
  public:
   /**
    * \brief Constructs RateBoundstatus, which inherits diagnostic_updater::DiagnosticTask.
@@ -106,7 +66,7 @@ private:
    * \param num_frame_transition The number of the successive observations for the status
    * transition. E.g., the status will not be changed from OK to WARN until successive
    * `num_frame_transition` WARNs are observed.
-   * \param immediate_error_report If true (default), errors related to the rate bounds will be
+   * \param immediate_error_report If true, errors related to the rate bounds will be
    * reported immediately once observed; otherwise, the hysteresis damping method using
    * `num_frame_transition` will be adopted
    * \param name The arbitrary string to be assigned for this diagnostic task.
@@ -116,12 +76,15 @@ private:
                   const RateBoundStatusParam& ok_params,
                   const RateBoundStatusParam& warn_params,
                   const size_t num_frame_transition = 1,
-                  const bool immediate_error_report = true,
+                  const bool immediate_error_report = false,
+                  const bool immediate_relax_state = true,
                   const std::string& name = "rate bound check")
       : DiagnosticTask(name), ok_params_(ok_params), warn_params_(warn_params),
         num_frame_transition_(num_frame_transition),
-        immediate_error_report_(immediate_error_report), zero_seen_(false),
-        candidate_state_(Stale{}), current_state_(Stale{})
+        zero_seen_(false),
+        hysteresys_state_machine_(num_frame_transition, immediate_error_report,
+                                  immediate_relax_state),
+        current_state_(diagnostic_msgs::msg::DiagnosticStatus::STALE)
   {
     if (num_frame_transition < 1) {
       num_frame_transition_ = 1;
@@ -194,16 +157,16 @@ private:
     std::unique_lock<std::mutex> lock(lock_);
 
     // classify the current observation
-    StateHolder frame_result;
+    DiagnosticStatus_t frame_result;
     if (!frequency_ || zero_seen_) {
-      frame_result.emplace<Stale>();
+      frame_result = diagnostic_msgs::msg::DiagnosticStatus::STALE;
     } else {
       if (is_ok(frequency_.value())) {
-        frame_result.emplace<Ok>();
+        frame_result = diagnostic_msgs::msg::DiagnosticStatus::OK;
       } else if (is_warn(frequency_.value())) {
-        frame_result.emplace<Warn>();
+        frame_result = diagnostic_msgs::msg::DiagnosticStatus::WARN;
       } else {
-        frame_result.emplace<Error>();
+        frame_result = diagnostic_msgs::msg::DiagnosticStatus::ERROR;
       }
     }
 
@@ -216,7 +179,7 @@ private:
       double freq_from_prev_tick = 1. / delta;
       // If the latest update too older than warn_params_ criteria, frame_result fires error
       if (freq_from_prev_tick < warn_params_.min_frequency) {
-        frame_result.emplace<Error>();
+        frame_result = diagnostic_msgs::msg::DiagnosticStatus::ERROR;
         is_valid_observation = false;
         frequency_ = freq_from_prev_tick;
         auto max_frame_period_s = 1. / warn_params_.min_frequency;
@@ -225,46 +188,28 @@ private:
       }
     }
 
-    // If the classify result is same as previous one, count the number of observation
-    // Otherwise, update candidate
-    if (candidate_state_.index() == frame_result.index() &&
-        candidate_state_.index() != current_state_.index()) {
-      // if result has the same status as candidate but differenct from current
-      std::visit([](auto& s){
-        s.num_observations += 1;
-      }, candidate_state_);
-    } else {
-      candidate_state_ = frame_result;
+    // Update state using hysteresis
+    current_state_ = hysteresys_state_machine_.update_state(frame_result, current_state_);
+    if (!is_valid_observation && num_frame_skipped >= num_frame_transition_) {
+      current_state_ = diagnostic_msgs::msg::DiagnosticStatus::ERROR;
     }
 
-    // Update the current state if
-    // - immediate error report is required and the observed state is error
-    // - Or the same state is observed multiple times
-    if ((immediate_error_report_ && std::holds_alternative<Error>(candidate_state_)) ||
-        (is_valid_observation && get_num_observations(candidate_state_) >= num_frame_transition_) ||
-        (!is_valid_observation && num_frame_skipped >= num_frame_transition_)) {
-      current_state_ = candidate_state_;
-      std::visit([](auto& s) {
-        s.num_observations = 1;
-      }, candidate_state_);
-    }
-
-    stat.summary(get_level(current_state_), get_msg(current_state_));
+    stat.summary(current_state_, generate_msg(current_state_));
 
     std::stringstream ss;
     ss << std::fixed << std::setprecision(2) << frequency_.value_or(0.0);
     stat.add("Publish rate", ss.str());
 
     ss.str(""); // reset contents
-    ss << get_level_string(get_level(current_state_));
+    ss << get_level_string(current_state_);
     stat.add("Effective rate status", ss.str());
 
     ss.str(""); // reset contents
-    ss << get_level_string(get_level(candidate_state_));
+    ss << get_level_string(hysteresys_state_machine_.get_candidate_level());
     stat.add("Candidate rate status", ss.str());
 
     ss.str(""); // reset contents
-    ss << get_num_observations(candidate_state_);
+    ss << hysteresys_state_machine_.get_candidate_num_observation();
     stat.add("Candidate status observed frames", ss.str());
 
     ss.str("");  // reset contents
@@ -300,14 +245,13 @@ protected:
   RateBoundStatusParam ok_params_;
   RateBoundStatusParam warn_params_;
   size_t num_frame_transition_;
-  bool immediate_error_report_;
   bool zero_seen_;
   std::optional<double> frequency_;
   std::optional<double> previous_frame_timestamp_;
   std::mutex lock_;
 
-  StateHolder candidate_state_;
-  StateHolder current_state_;
+  HysteresisStateMachine hysteresys_state_machine_;
+  DiagnosticStatus_t current_state_;
 
   std::shared_ptr<rclcpp::Clock> clock_;
 
@@ -315,31 +259,26 @@ protected:
     return clock_->now().seconds();
   }
 
-  static unsigned char get_level(const StateHolder& state) {
-    return std::visit([](const auto& s){return s.level;}, state);
-  }
-
-  static size_t get_num_observations(const StateHolder& state) {
-    return std::visit([](const auto& s){return s.num_observations;}, state);
-  }
-
-  static std::string get_msg(const StateHolder& state) {
-    return std::visit([](const auto& s){return s.msg;}, state);
-  }
-
-  static std::string get_level_string(unsigned char level) {
-    switch(level) {
+  static std::string generate_msg(const DiagnosticStatus_t& state) {
+    std::string ret;
+    switch(state) {
       case diagnostic_msgs::msg::DiagnosticStatus::OK:
-        return "OK";
+        ret = "Rate is reasonable";
+        break;
       case diagnostic_msgs::msg::DiagnosticStatus::WARN:
-        return "WARN";
+        ret = "Rate is within warning range";
+        break;
       case diagnostic_msgs::msg::DiagnosticStatus::ERROR:
-        return "ERROR";
+        ret = "Rate is out of valid range";
+        break;
       case diagnostic_msgs::msg::DiagnosticStatus::STALE:
-        return "STALE";
+        ret = "Topic has not been received yet";
+        break;
       default:
-        return "UNDEFINED";
+        ret = "Undefined state";
+        break;
     }
+    return ret;
   }
 
 };  // class RateBoundStatus

--- a/include/v4l2_camera/rate_bound_status.hpp
+++ b/include/v4l2_camera/rate_bound_status.hpp
@@ -239,6 +239,15 @@ class RateBoundStatus : public diagnostic_updater::DiagnosticTask
       ss << std::fixed << std::setprecision(2) << warn_params_.max_frequency.value();
       stat.add("Maximum WARN rate threshold", ss.str());
     }
+
+    ss.str("");  // reset contents
+    ss << (hysteresis_state_machine_.get_immediate_error_report_param() ? "true" : "false");
+    stat.add("Immediate error report", ss.str());
+
+    ss.str("");  // reset contents
+    ss << (hysteresis_state_machine_.get_immediate_relax_state_param() ? "true" : "false");
+    stat.add("Immediate relax state", ss.str());
+
   }
 
 protected:

--- a/include/v4l2_camera/rate_bound_status.hpp
+++ b/include/v4l2_camera/rate_bound_status.hpp
@@ -16,19 +16,20 @@
 #define RATE_BOUND_STATUS_HPP_
 
 #include <diagnostic_updater/diagnostic_updater.hpp>
+#include <v4l2_camera/hysteresis_state_machine.hpp>
 
 #include <diagnostic_msgs/msg/diagnostic_status.hpp>
 
+#include <rcl/time.h>
+
 #include <iomanip>
 #include <limits>
+#include <memory>
 #include <mutex>
 #include <optional>
-#include <rcl/time.h>
 #include <sstream>
 #include <stdexcept>
 #include <string>
-
-#include <v4l2_camera/hysteresis_state_machine.hpp>
 
 namespace custom_diagnostic_tasks
 {
@@ -38,8 +39,11 @@ namespace custom_diagnostic_tasks
  */
 struct RateBoundStatusParam
 {
-  explicit RateBoundStatusParam(const double min_freq, const std::optional<double> max_freq = std::nullopt)
-      : min_frequency(min_freq), max_frequency(max_freq){}
+  explicit RateBoundStatusParam(
+    const double min_freq, const std::optional<double> max_freq = std::nullopt)
+  : min_frequency(min_freq), max_frequency(max_freq)
+  {
+  }
 
   double min_frequency;
   std::optional<double> max_frequency;
@@ -54,10 +58,11 @@ struct RateBoundStatusParam
  */
 class RateBoundStatus : public diagnostic_updater::DiagnosticTask
 {
- public:
+public:
   /**
-   * \brief Constructs RateBoundstatus, which inherits diagnostic_updater::DiagnosticTask.
+   * \brief Constructs RateBoundStatus, which inherits diagnostic_updater::DiagnosticTask.
    *
+   * \param parent_node The node from which parameters are read.
    * \param ok_params The pair of min/max frequency for the topic rate to be recognized as "OK".
    * \param warn_params The pair of min/max frequency for the topic rate to be recognized as "WARN".
    * These values should have a wider range than `ok_params`.
@@ -70,19 +75,17 @@ class RateBoundStatus : public diagnostic_updater::DiagnosticTask
    * \param name The arbitrary string to be assigned for this diagnostic task.
    * This name will not be exposed in the actual published topics.
    */
-  RateBoundStatus(const rclcpp::Node* parent_node,
-                  const RateBoundStatusParam& ok_params,
-                  const RateBoundStatusParam& warn_params,
-                  const size_t num_frame_transition = 1,
-                  const bool immediate_error_report = false,
-                  const bool immediate_relax_state = true,
-                  const std::string& name = "rate bound check")
-      : DiagnosticTask(name), ok_params_(ok_params), warn_params_(warn_params),
-        num_frame_transition_(num_frame_transition),
-        zero_seen_(false),
-        hysteresis_state_machine_(num_frame_transition, immediate_error_report,
-                                  immediate_relax_state),
-        current_state_(diagnostic_msgs::msg::DiagnosticStatus::STALE)
+  RateBoundStatus(
+    const rclcpp::Node * parent_node, const RateBoundStatusParam & ok_params,
+    const RateBoundStatusParam & warn_params, const size_t num_frame_transition = 1,
+    const bool immediate_error_report = false, const bool immediate_relax_state = true,
+    const std::string & name = "rate bound check")
+  : DiagnosticTask(name),
+    ok_params_(ok_params),
+    warn_params_(warn_params),
+    num_frame_transition_(num_frame_transition),
+    zero_seen_(false),
+    hysteresis_state_machine_(num_frame_transition, immediate_error_report, immediate_relax_state)
   {
     if (num_frame_transition < 1) {
       num_frame_transition_ = 1;
@@ -91,11 +94,11 @@ class RateBoundStatus : public diagnostic_updater::DiagnosticTask
     // Confirm `warn_params` surely has wider range than `ok_params`
     if (warn_params_.min_frequency >= ok_params_.min_frequency) {
       throw std::runtime_error(
-          "Invalid range parameters were detected. warn_params should specify a range "
-          "that includes a range of ok_params.");
+        "Invalid range parameters were detected. warn_params should specify a range "
+        "that includes a range of ok_params.");
     }
 
-    // select clock according to the use_sim_time paramter set to the parent
+    // select clock according to the use_sim_time parameter set to the parent
     bool use_sim_time = false;
     if (parent_node->has_parameter("use_sim_time")) {
       use_sim_time = parent_node->get_parameter("use_sim_time").as_bool();
@@ -121,13 +124,15 @@ class RateBoundStatus : public diagnostic_updater::DiagnosticTask
     } else {
       zero_seen_ = false;
       double delta = stamp - previous_frame_timestamp_.value();
-      frequency_ = (delta < 10 * std::numeric_limits<double>::epsilon()) ?
-                   std::numeric_limits<double>::infinity() : 1. / delta;
+      frequency_ = (delta < 10 * std::numeric_limits<double>::epsilon())
+                     ? std::numeric_limits<double>::infinity()
+                     : 1. / delta;
     }
     previous_frame_timestamp_ = stamp;
   }
 
-  bool is_ok(double observation) {
+  bool is_ok(double observation)
+  {
     bool result = ok_params_.min_frequency < observation;
     if (ok_params_.max_frequency) {
       // If the max_frequency is defined, consider the upper bound
@@ -136,9 +141,10 @@ class RateBoundStatus : public diagnostic_updater::DiagnosticTask
     return result;
   }
 
-  bool is_warn(double observation) {
-    bool result = (warn_params_.min_frequency <= observation &&
-                   observation <= ok_params_.min_frequency);
+  bool is_warn(double observation)
+  {
+    bool result =
+      (warn_params_.min_frequency <= observation && observation <= ok_params_.min_frequency);
     if (ok_params_.max_frequency && warn_params_.max_frequency) {
       // If the max_frequency is defined, consider the upper bound
       result = result || (ok_params_.max_frequency <= observation &&
@@ -150,7 +156,7 @@ class RateBoundStatus : public diagnostic_updater::DiagnosticTask
   /**
    * \brief function called every update
    */
-  void run(diagnostic_updater::DiagnosticStatusWrapper& stat) override
+  void run(diagnostic_updater::DiagnosticStatusWrapper & stat) override
   {
     std::unique_lock<std::mutex> lock(lock_);
 
@@ -182,7 +188,7 @@ class RateBoundStatus : public diagnostic_updater::DiagnosticTask
         frequency_ = freq_from_prev_tick;
         auto max_frame_period_s = 1. / warn_params_.min_frequency;
         // Minimum frames to assume skipped if 'tick' calls occur at 'warn_params_.min_frequency'.
-        num_frame_skipped  = static_cast<size_t>(delta / max_frame_period_s);
+        num_frame_skipped = static_cast<size_t>(delta / max_frame_period_s);
       }
     }
 
@@ -190,25 +196,25 @@ class RateBoundStatus : public diagnostic_updater::DiagnosticTask
     hysteresis_state_machine_.update_state(frame_result);
     if (!is_valid_observation && num_frame_skipped >= num_frame_transition_) {
       hysteresis_state_machine_.set_current_state_level(
-          diagnostic_msgs::msg::DiagnosticStatus::ERROR);
+        diagnostic_msgs::msg::DiagnosticStatus::ERROR);
     }
-    current_state_ = hysteresis_state_machine_.get_current_state_level();
 
-    stat.summary(current_state_, generate_msg(current_state_));
+    auto current_state = hysteresis_state_machine_.get_current_state_level();
+    stat.summary(current_state, generate_msg(current_state));
 
     std::stringstream ss;
     ss << std::fixed << std::setprecision(2) << frequency_.value_or(0.0);
     stat.add("Publish rate", ss.str());
 
-    ss.str(""); // reset contents
-    ss << get_level_string(current_state_);
+    ss.str("");  // reset contents
+    ss << get_level_string(current_state);
     stat.add("Effective rate status", ss.str());
 
-    ss.str(""); // reset contents
+    ss.str("");  // reset contents
     ss << get_level_string(hysteresis_state_machine_.get_candidate_level());
     stat.add("Candidate rate status", ss.str());
 
-    ss.str(""); // reset contents
+    ss.str("");  // reset contents
     ss << hysteresis_state_machine_.get_candidate_num_observation();
     stat.add("Candidate status observed frames", ss.str());
 
@@ -247,7 +253,6 @@ class RateBoundStatus : public diagnostic_updater::DiagnosticTask
     ss.str("");  // reset contents
     ss << (hysteresis_state_machine_.get_immediate_relax_state_param() ? "true" : "false");
     stat.add("Immediate relax state", ss.str());
-
   }
 
 protected:
@@ -260,17 +265,15 @@ protected:
   std::mutex lock_;
 
   HysteresisStateMachine hysteresis_state_machine_;
-  DiagnosticStatus_t current_state_;
 
   std::shared_ptr<rclcpp::Clock> clock_;
 
-  inline double get_now() {
-    return clock_->now().seconds();
-  }
+  inline double get_now() { return clock_->now().seconds(); }
 
-  static std::string generate_msg(const DiagnosticStatus_t& state) {
+  static std::string generate_msg(const DiagnosticStatus_t & state)
+  {
     std::string ret;
-    switch(state) {
+    switch (state) {
       case diagnostic_msgs::msg::DiagnosticStatus::OK:
         ret = "Rate is reasonable";
         break;
@@ -289,7 +292,6 @@ protected:
     }
     return ret;
   }
-
 };  // class RateBoundStatus
 
 }  // namespace custom_diagnostic_tasks

--- a/include/v4l2_camera/rate_bound_status.hpp
+++ b/include/v4l2_camera/rate_bound_status.hpp
@@ -19,7 +19,6 @@
 
 #include <diagnostic_msgs/msg/diagnostic_status.hpp>
 
-#include <chrono>
 #include <iomanip>
 #include <limits>
 #include <mutex>
@@ -28,7 +27,6 @@
 #include <sstream>
 #include <stdexcept>
 #include <string>
-#include <variant>
 
 #include <v4l2_camera/hysteresis_state_machine.hpp>
 

--- a/include/v4l2_camera/rate_bound_status.hpp
+++ b/include/v4l2_camera/rate_bound_status.hpp
@@ -227,7 +227,9 @@ private:
 
     // If the classify result is same as previous one, count the number of observation
     // Otherwise, update candidate
-    if (candidate_state_.index() == frame_result.index()) {  // if result has the same status as candidate
+    if (candidate_state_.index() == frame_result.index() &&
+        candidate_state_.index() != current_state_.index()) {
+      // if result has the same status as candidate but differenct from current
       std::visit([](auto& s){
         s.num_observations += 1;
       }, candidate_state_);
@@ -253,9 +255,25 @@ private:
     ss << std::fixed << std::setprecision(2) << frequency_.value_or(0.0);
     stat.add("Publish rate", ss.str());
 
+    ss.str(""); // reset contents
+    ss << get_level_string(get_level(current_state_));
+    stat.add("Effective rate status", ss.str());
+
+    ss.str(""); // reset contents
+    ss << get_level_string(get_level(candidate_state_));
+    stat.add("Candidate rate status", ss.str());
+
+    ss.str(""); // reset contents
+    ss << get_num_observations(candidate_state_);
+    stat.add("Candidate status observed frames", ss.str());
+
     ss.str("");  // reset contents
-    ss << get_level_string(get_level(frame_result));
-    stat.add("Rate status", ss.str());
+    ss << num_frame_skipped;
+    stat.add("Assumed skipped frames", ss.str());
+
+    ss.str("");  // reset contents
+    ss << num_frame_transition_;
+    stat.add("Observed frames transition threshold", ss.str());
 
     ss.str("");  // reset contents
     ss << std::fixed << std::setprecision(2) << ok_params_.min_frequency;
@@ -276,18 +294,6 @@ private:
       ss << std::fixed << std::setprecision(2) << warn_params_.max_frequency.value();
       stat.add("Maximum WARN rate threshold", ss.str());
     }
-
-    ss.str("");  // reset contents
-    ss << get_num_observations(candidate_state_);
-    stat.add("Observed frames", ss.str());
-
-    ss.str("");  // reset contents
-    ss << num_frame_skipped;
-    stat.add("Assumed skipped frames", ss.str());
-
-    ss.str("");  // reset contents
-    ss << num_frame_transition_;
-    stat.add("Observed frames transition threshold", ss.str());
   }
 
 protected:

--- a/include/v4l2_camera/rate_bound_status.hpp
+++ b/include/v4l2_camera/rate_bound_status.hpp
@@ -38,11 +38,11 @@ namespace custom_diagnostic_tasks
  */
 struct RateBoundStatusParam
 {
-  RateBoundStatusParam(const double min_freq, const double max_freq)
+  RateBoundStatusParam(const double min_freq, const std::optional<double> max_freq = std::nullopt)
       : min_frequency(min_freq), max_frequency(max_freq){}
 
   double min_frequency;
-  double max_frequency;
+  std::optional<double> max_frequency;
 };
 
 /**
@@ -128,8 +128,7 @@ private:
     }
 
     // Confirm `warn_params` surely has wider range than `ok_params`
-    if (warn_params_.min_frequency >= ok_params_.min_frequency ||
-      ok_params_.max_frequency >= warn_params_.max_frequency) {
+    if (warn_params_.min_frequency >= ok_params_.min_frequency) {
       throw std::runtime_error(
           "Invalid range parameters were detected. warn_params should specify a range "
           "that includes a range of ok_params.");
@@ -167,6 +166,26 @@ private:
     previous_frame_timestamp_ = stamp;
   }
 
+  bool is_ok(double observation) {
+    bool result = ok_params_.min_frequency < observation;
+    if (ok_params_.max_frequency) {
+      // If the max_frequency is defined, consider the upper bound
+      result = result && (observation < ok_params_.max_frequency);
+    }
+    return result;
+  }
+
+  bool is_warn(double observation) {
+    bool result = (warn_params_.min_frequency <= observation &&
+                   observation <= ok_params_.min_frequency);
+    if (ok_params_.max_frequency && warn_params_.max_frequency) {
+      // If the max_frequency is defined, consider the upper bound
+      result = result || (ok_params_.max_frequency <= observation &&
+                          observation <= warn_params_.max_frequency);
+    }
+    return result;
+  }
+
   /**
    * \brief function called every update
    */
@@ -179,10 +198,9 @@ private:
     if (!frequency_ || zero_seen_) {
       frame_result.emplace<Stale>();
     } else {
-      if (ok_params_.min_frequency < frequency_ && frequency_ < ok_params_.max_frequency) {
+      if (is_ok(frequency_.value())) {
         frame_result.emplace<Ok>();
-      } else if ((warn_params_.min_frequency <= frequency_ && frequency_ <= ok_params_.min_frequency) ||
-                 (ok_params_.max_frequency <= frequency_ && frequency_ <= warn_params_.max_frequency)) {
+      } else if (is_warn(frequency_.value())) {
         frame_result.emplace<Warn>();
       } else {
         frame_result.emplace<Error>();
@@ -243,17 +261,21 @@ private:
     ss << std::fixed << std::setprecision(2) << ok_params_.min_frequency;
     stat.add("Minimum OK rate threshold", ss.str());
 
-    ss.str("");  // reset contents
-    ss << std::fixed << std::setprecision(2) << ok_params_.max_frequency;
-    stat.add("Maximum OK rate threshold", ss.str());
+    if (ok_params_.max_frequency) {
+      ss.str("");  // reset contents
+      ss << std::fixed << std::setprecision(2) << ok_params_.max_frequency.value();
+      stat.add("Maximum OK rate threshold", ss.str());
+    }
 
     ss.str("");  // reset contents
     ss << std::fixed << std::setprecision(2) << warn_params_.min_frequency;
     stat.add("Minimum WARN rate threshold", ss.str());
 
-    ss.str("");  // reset contents
-    ss << std::fixed << std::setprecision(2) << warn_params_.max_frequency;
-    stat.add("Maximum WARN rate threshold", ss.str());
+    if (warn_params_.max_frequency) {
+      ss.str("");  // reset contents
+      ss << std::fixed << std::setprecision(2) << warn_params_.max_frequency.value();
+      stat.add("Maximum WARN rate threshold", ss.str());
+    }
 
     ss.str("");  // reset contents
     ss << get_num_observations(candidate_state_);

--- a/include/v4l2_camera/rate_bound_status.hpp
+++ b/include/v4l2_camera/rate_bound_status.hpp
@@ -40,7 +40,7 @@ namespace custom_diagnostic_tasks
  */
 struct RateBoundStatusParam
 {
-  RateBoundStatusParam(const double min_freq, const std::optional<double> max_freq = std::nullopt)
+  explicit RateBoundStatusParam(const double min_freq, const std::optional<double> max_freq = std::nullopt)
       : min_frequency(min_freq), max_frequency(max_freq){}
 
   double min_frequency;
@@ -82,7 +82,7 @@ class RateBoundStatus : public diagnostic_updater::DiagnosticTask
       : DiagnosticTask(name), ok_params_(ok_params), warn_params_(warn_params),
         num_frame_transition_(num_frame_transition),
         zero_seen_(false),
-        hysteresys_state_machine_(num_frame_transition, immediate_error_report,
+        hysteresis_state_machine_(num_frame_transition, immediate_error_report,
                                   immediate_relax_state),
         current_state_(diagnostic_msgs::msg::DiagnosticStatus::STALE)
   {
@@ -157,7 +157,7 @@ class RateBoundStatus : public diagnostic_updater::DiagnosticTask
     std::unique_lock<std::mutex> lock(lock_);
 
     // classify the current observation
-    DiagnosticStatus_t frame_result;
+    DiagnosticStatus_t frame_result{};
     if (!frequency_ || zero_seen_) {
       frame_result = diagnostic_msgs::msg::DiagnosticStatus::STALE;
     } else {
@@ -189,7 +189,7 @@ class RateBoundStatus : public diagnostic_updater::DiagnosticTask
     }
 
     // Update state using hysteresis
-    current_state_ = hysteresys_state_machine_.update_state(frame_result, current_state_);
+    current_state_ = hysteresis_state_machine_.update_state(frame_result, current_state_);
     if (!is_valid_observation && num_frame_skipped >= num_frame_transition_) {
       current_state_ = diagnostic_msgs::msg::DiagnosticStatus::ERROR;
     }
@@ -205,11 +205,11 @@ class RateBoundStatus : public diagnostic_updater::DiagnosticTask
     stat.add("Effective rate status", ss.str());
 
     ss.str(""); // reset contents
-    ss << get_level_string(hysteresys_state_machine_.get_candidate_level());
+    ss << get_level_string(hysteresis_state_machine_.get_candidate_level());
     stat.add("Candidate rate status", ss.str());
 
     ss.str(""); // reset contents
-    ss << hysteresys_state_machine_.get_candidate_num_observation();
+    ss << hysteresis_state_machine_.get_candidate_num_observation();
     stat.add("Candidate status observed frames", ss.str());
 
     ss.str("");  // reset contents
@@ -250,7 +250,7 @@ protected:
   std::optional<double> previous_frame_timestamp_;
   std::mutex lock_;
 
-  HysteresisStateMachine hysteresys_state_machine_;
+  HysteresisStateMachine hysteresis_state_machine_;
   DiagnosticStatus_t current_state_;
 
   std::shared_ptr<rclcpp::Clock> clock_;

--- a/include/v4l2_camera/rate_bound_status.hpp
+++ b/include/v4l2_camera/rate_bound_status.hpp
@@ -187,10 +187,12 @@ class RateBoundStatus : public diagnostic_updater::DiagnosticTask
     }
 
     // Update state using hysteresis
-    current_state_ = hysteresis_state_machine_.update_state(frame_result, current_state_);
+    hysteresis_state_machine_.update_state(frame_result);
     if (!is_valid_observation && num_frame_skipped >= num_frame_transition_) {
-      current_state_ = diagnostic_msgs::msg::DiagnosticStatus::ERROR;
+      hysteresis_state_machine_.set_current_state_level(
+          diagnostic_msgs::msg::DiagnosticStatus::ERROR);
     }
+    current_state_ = hysteresis_state_machine_.get_current_state_level();
 
     stat.summary(current_state_, generate_msg(current_state_));
 
@@ -215,7 +217,7 @@ class RateBoundStatus : public diagnostic_updater::DiagnosticTask
     stat.add("Assumed skipped frames", ss.str());
 
     ss.str("");  // reset contents
-    ss << num_frame_transition_;
+    ss << hysteresis_state_machine_.get_num_frame_transition();
     stat.add("Observed frames transition threshold", ss.str());
 
     ss.str("");  // reset contents


### PR DESCRIPTION
# Description
This PR updates `rate_bound_status` in the following manner:
- Made upper bound parameters optional
  - If `ok_params.max_frequency` and `warn_params.max_frequency` are specified explicitly, `RateBoundStatus` considers them (i.e., checks both lower and upper bounds of the frequency); otherwise, it only monitors the lower bound
- Rearrange key-values to make them easy to understand
- Extract the hysteresis part into a separate class, named `HysteresisStateMachine`, so that this filter can be reused for other types of diagnostics
  - This class newly introduces a parameter named `immediate_relax_state` (default `true`). If this parameter is set to true, the filtered state will be immediately changed if the observed state is better than the current state

After udpate, the diagnostics looks like:
<img width="2160" height="1920" alt="Screenshot from 2025-10-21 12-04-06" src="https://github.com/user-attachments/assets/e633c7c9-1f3b-49a7-bcda-098a0dea4d57" />
(2025/Oct/21 screencapture updated)


# How to test
1. execute v4l2 loopback to emurate v4l2 camera
  ```bash
  sudo modprobe v4l2loopback
  ffmpeg -re -i <any mp4 file> -r 10 -map 0:v -vf format=yuyv422  -f v4l2 /dev/video0
  sudo modprobe -r v4l2loopback
  ```
2. run ros2_v4l2
  ```bash
  ros2 run v4l2_camera v4l2_camera_node
  ```