### PR TITLE
feat: add image width check before convert on GPU

### DIFF
--- a/include/v4l2_camera/v4l2_camera.hpp
+++ b/include/v4l2_camera/v4l2_camera.hpp
@@ -163,6 +163,9 @@ private:
   bool checkCameraInfo(
     sensor_msgs::msg::Image const & img,
     sensor_msgs::msg::CameraInfo const & ci);
+
+  /// True if width, height, step, and buffer size are consistent and match the active V4L2 format.
+  bool validatePublishedImage(sensor_msgs::msg::Image const & img);
 };
 
 }  // namespace v4l2_camera

--- a/src/v4l2_camera.cpp
+++ b/src/v4l2_camera.cpp
@@ -350,8 +350,8 @@ V4L2Camera::V4L2Camera(rclcpp::NodeOptions const & options)
           img = convert(*img);
 #endif
           if (img == nullptr) {
-            RCLCPP_WARN_THROTTLE(
-              get_logger(), *get_clock(), 5000,
+            RCLCPP_WARN(
+              get_logger(),
               "Skip publish: pixel format conversion failed");
             continue;
           }

--- a/src/v4l2_camera.cpp
+++ b/src/v4l2_camera.cpp
@@ -139,14 +139,14 @@ bool V4L2Camera::validatePublishedImage(sensor_msgs::msg::Image const & img)
 {
   constexpr uint32_t maxReasonableDimension = 16384u;
   if (img.width == 0u || img.height == 0u) {
-    RCLCPP_WARN_THROTTLE(
-      get_logger(), *get_clock(), 5000,
+    RCLCPP_WARN(
+      get_logger(),
       "Skip publish: invalid dimensions %ux%u", img.width, img.height);
     return false;
   }
   if (img.width > maxReasonableDimension || img.height > maxReasonableDimension) {
-    RCLCPP_WARN_THROTTLE(
-      get_logger(), *get_clock(), 5000,
+    RCLCPP_WARN(
+      get_logger(),
       "Skip publish: dimensions exceed sanity bound (%ux%u)", img.width, img.height);
     return false;
   }

--- a/src/v4l2_camera.cpp
+++ b/src/v4l2_camera.cpp
@@ -792,6 +792,11 @@ bool V4L2Camera::checkCameraInfo(
 #ifdef ENABLE_CUDA
 sensor_msgs::msg::Image::UniquePtr V4L2Camera::convertOnGpu(sensor_msgs::msg::Image const & img)
 {
+  if (img.width == 0) {
+    RCLCPP_WARN_ONCE(get_logger(), "Received zero-width image; skipping GPU conversion");
+    return nullptr;
+  }
+
   if ((img.encoding != sensor_msgs::image_encodings::YUV422 &&
        img.encoding != sensor_msgs::image_encodings::YUV422_YUY2) ||
       output_encoding_ != sensor_msgs::image_encodings::RGB8) {

--- a/src/v4l2_camera.cpp
+++ b/src/v4l2_camera.cpp
@@ -135,6 +135,25 @@ static void diagnoseStreamLiveness(
   is_frame_updated = false;
 }  // static void diagnoseStreamLiveness
 
+bool V4L2Camera::validatePublishedImage(sensor_msgs::msg::Image const & img)
+{
+  constexpr uint32_t maxReasonableDimension = 16384u;
+  if (img.width == 0u || img.height == 0u) {
+    RCLCPP_WARN_THROTTLE(
+      get_logger(), *get_clock(), 5000,
+      "Skip publish: invalid dimensions %ux%u", img.width, img.height);
+    return false;
+  }
+  if (img.width > maxReasonableDimension || img.height > maxReasonableDimension) {
+    RCLCPP_WARN_THROTTLE(
+      get_logger(), *get_clock(), 5000,
+      "Skip publish: dimensions exceed sanity bound (%ux%u)", img.width, img.height);
+    return false;
+  }
+
+  return true;
+}
+
 V4L2Camera::V4L2Camera(rclcpp::NodeOptions const & options)
 : rclcpp::Node{"v4l2_camera", options},
   canceled_{false}
@@ -316,7 +335,10 @@ V4L2Camera::V4L2Camera(rclcpp::NodeOptions const & options)
           std::this_thread::sleep_for(std::chrono::milliseconds(10));
           continue;
         }
-        if(publish_next_frame_ == false){
+        if (publish_next_frame_ == false) {
+          continue;
+        }
+        if (!validatePublishedImage(*img)) {
           continue;
         }
 
@@ -327,6 +349,15 @@ V4L2Camera::V4L2Camera(rclcpp::NodeOptions const & options)
 #else
           img = convert(*img);
 #endif
+          if (img == nullptr) {
+            RCLCPP_WARN_THROTTLE(
+              get_logger(), *get_clock(), 5000,
+              "Skip publish: pixel format conversion failed");
+            continue;
+          }
+          if (!validatePublishedImage(*img)) {
+            continue;
+          }
         }
         img->header.stamp = stamp;
         img->header.frame_id = camera_frame_id_;
@@ -792,11 +823,6 @@ bool V4L2Camera::checkCameraInfo(
 #ifdef ENABLE_CUDA
 sensor_msgs::msg::Image::UniquePtr V4L2Camera::convertOnGpu(sensor_msgs::msg::Image const & img)
 {
-  if (img.width == 0) {
-    RCLCPP_WARN_ONCE(get_logger(), "Received zero-width image; skipping GPU conversion");
-    return nullptr;
-  }
-
   if ((img.encoding != sensor_msgs::image_encodings::YUV422 &&
        img.encoding != sensor_msgs::image_encodings::YUV422_YUY2) ||
       output_encoding_ != sensor_msgs::image_encodings::RGB8) {


### PR DESCRIPTION
# Description
We had a glog report from X2 MJ20-019:
```
Apr 23 08:57:00 perception2 run.sh[2989]: [component_container_mt-4] PC: @                0x0 (unknown)
Apr 23 08:57:00 perception2 run.sh[2989]: [component_container_mt-4] *** SIGABRT (@0xbd5) received by PID 3029 (TID 0xffff563d19a0) from PID 3029; stack trace: ***
Apr 23 08:57:00 perception2 run.sh[2989]: [component_container_mt-4]     @     0xffffa8602050 google::(anonymous namespace)::FailureSignalHandler()
Apr 23 08:57:00 perception2 run.sh[2989]: [component_container_mt-4]     @     0xffffafa6e7c0 ([vdso]+0x7bf)
Apr 23 08:57:00 perception2 run.sh[2989]: [component_container_mt-4]     @     0xffffaf398d78 gsignal
Apr 23 08:57:00 perception2 run.sh[2989]: [component_container_mt-4]     @     0xffffaf385aac abort
Apr 23 08:57:00 perception2 run.sh[2989]: [component_container_mt-4]     @     0xffffaf59d8cc __gnu_cxx::__verbose_terminate_handler()
Apr 23 08:57:00 perception2 run.sh[2989]: [component_container_mt-4]     @     0xffffaf59b21c (unknown)
Apr 23 08:57:00 perception2 run.sh[2989]: [component_container_mt-4]     @     0xffffaf59b280 std::terminate()
Apr 23 08:57:00 perception2 run.sh[2989]: [component_container_mt-4]     @     0xffffaf59b574 __cxa_throw
Apr 23 08:57:00 perception2 run.sh[2989]: [component_container_mt-4]     @     0xffffa848e8f4 v4l2_camera::cudaErrorCheck()
Apr 23 08:57:01 perception2 run.sh[2989]: [component_container_mt-4]     @     0xffffa848f26c v4l2_camera::V4L2Camera::()
```
So I'm considering adding some checks and protection before passing the image message to the next layer. Add a check before and after `convertOnGpu`.

Tested on Bench No3 with five restarts. No abnormal happened.