### PR TITLE
fix: reproduce parameter name generation convention of v4l2-ctl

### DIFF
--- a/src/v4l2_camera.cpp
+++ b/src/v4l2_camera.cpp
@@ -15,6 +15,7 @@
 #include "v4l2_camera/v4l2_camera.hpp"
 #include "v4l2_camera/rate_bound_status.hpp"
 
+#include <cctype>
 #include <diagnostic_updater/update_functions.hpp>
 #include <rclcpp/parameter_value.hpp>
 #include <rclcpp/qos.hpp>
@@ -503,15 +504,32 @@ void V4L2Camera::createParameters()
   }
 
   // Control parameters
-  auto toParamName =
-    [](std::string name) {
-      std::transform(name.begin(), name.end(), name.begin(), ::tolower);
-      name.erase(std::remove(name.begin(), name.end(), ','), name.end());
-      name.erase(std::remove(name.begin(), name.end(), '('), name.end());
-      name.erase(std::remove(name.begin(), name.end(), ')'), name.end());
-      std::replace(name.begin(), name.end(), ' ', '_');
-      return name;
-    };
+  auto toParamName = [](std::string name) {
+    // Normalize control names using v4l2-ctl's naming convention:
+    // lowercase letters, replace each run of non-alphanumeric characters with
+    // '_', and trim leading and trailing underscores.
+    std::transform(name.begin(), name.end(), name.begin(), [](unsigned char c) {
+      return static_cast<char>(std::tolower(c));
+    });
+    std::replace_if(
+        name.begin(), name.end(),
+        [](const unsigned char c) { return !std::isalnum(c); },
+        static_cast<char>('_'));
+    // Collapse consecutive underscores.
+    auto new_end =
+        std::unique(name.begin(), name.end(), [](auto left, auto right) {
+          return left == '_' && right == '_';
+        });
+    name.erase(new_end, name.end());
+    // Trim leading and trailing underscores.
+    if (!name.empty() && name.back() == '_') {
+      name.pop_back();
+    }
+    if (!name.empty() && name.front() == '_') {
+      name.erase(0, 1);
+    }
+    return name;
+  };
 
   for (auto const & c : camera_->getControls()) {
     auto name = toParamName(c.name);

--- a/src/v4l2_camera_device.cpp
+++ b/src/v4l2_camera_device.cpp
@@ -35,6 +35,12 @@
 using v4l2_camera::V4l2CameraDevice;
 using sensor_msgs::msg::Image;
 
+namespace {
+// Here assume camera is at least 10Hz -> total retry time would exceed 100ms
+constexpr int setControlMaxAttempts = 25;
+constexpr auto setControlRetryDelay = std::chrono::milliseconds{5};
+}
+
 V4l2CameraDevice::V4l2CameraDevice(std::string device, bool use_v4l2_buffer_timestamps, rclcpp::Duration timestamp_offset_duration)
 : device_{std::move(device)}, use_v4l2_buffer_timestamps_{use_v4l2_buffer_timestamps}, timestamp_offset_{timestamp_offset_duration}
 {
@@ -366,17 +372,40 @@ bool V4l2CameraDevice::setControlValue(uint32_t id, int32_t value)
   auto ctrl = v4l2_control{};
   ctrl.id = id;
   ctrl.value = value;
-  if (-1 == ioctl(fd_, VIDIOC_S_CTRL, &ctrl)) {
-    auto control = std::find_if(
-      controls_.begin(), controls_.end(),
-      [id](Control const & c) {return c.id == id;});
-    RCLCPP_ERROR(
-      rclcpp::get_logger("v4l2_camera"),
-      "Failed setting value for control %s to %s: %s (%s)", control->name.c_str(),
-      std::to_string(value).c_str(), strerror(errno), std::to_string(errno).c_str());
-    return false;
+
+  int error = 0;
+  int attempts = 0;
+  for (; attempts < setControlMaxAttempts; attempts++) {
+    if (ioctl(fd_, VIDIOC_S_CTRL, &ctrl) == 0) {
+      // success
+      return true;
+    }
+
+    error = errno;
+    if (error != EBUSY) {
+      // Assume non-EBUSY errors are fatal. return false immediately
+      break;
+    }
+
+    // Only if ioctl failed due to device/resource busy, retry configuration after some sleep
+    std::this_thread::sleep_for(setControlRetryDelay);
   }
-  return true;
+
+  auto control = std::find_if(controls_.begin(), controls_.end(),
+                              [id](Control const &c) { return c.id == id; });
+
+  auto message = std::ostringstream{};
+  if (error == EBUSY) {
+    message << "Failed setting value for control " << control->name << " to " << value
+            << " after " << attempts << " attempts: " << strerror(error) << "(" << error << ")";
+  } else {
+    // Fatal error
+    message << "Failed setting value for control" << control->name << " to " << value
+            << ": " << strerror(error) << "(" << error << ")";
+  }
+
+  RCLCPP_ERROR_STREAM(rclcpp::get_logger("v4l2_camera"), message.str());
+  return false;
 }
 
 bool V4l2CameraDevice::requestDataFormat(const PixelFormat & format)


### PR DESCRIPTION
This PR reproduces the way to generate parameter names based on how v4l2-ctl does.
Although the previous conversion only ignored `,`, `(`, and `)`, it was revealed that v4l2-ctl replaces all non-numeric and non-alphabetic characters with `_`, such as `[` and `]`. Since it may confuse users if the exposed ROS parameters and the parameters listed by `v4l2-ctl` are different, this PR aligns them.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>